### PR TITLE
Full rework of Ethernet HAL driver

### DIFF
--- a/Inc/stm32h7xx_hal_eth.h
+++ b/Inc/stm32h7xx_hal_eth.h
@@ -6,23 +6,22 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
-  */ 
+  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef STM32H7xx_HAL_ETH_H
 #define STM32H7xx_HAL_ETH_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 
@@ -37,23 +36,35 @@
 
 /** @addtogroup ETH
   * @{
-  */ 
+  */
 
 /* Exported types ------------------------------------------------------------*/
 #ifndef ETH_TX_DESC_CNT
- #define ETH_TX_DESC_CNT         4U
-#endif
-	 
+#define ETH_TX_DESC_CNT         4U
+#endif /* ETH_TX_DESC_CNT */
+
 #ifndef ETH_RX_DESC_CNT
- #define ETH_RX_DESC_CNT         4U
-#endif
+#define ETH_RX_DESC_CNT         4U
+#endif /* ETH_RX_DESC_CNT */
+
+#ifndef ETH_SWRESET_TIMEOUT
+#define ETH_SWRESET_TIMEOUT     ((uint32_t)500U)
+#endif /* ETH_SWRESET_TIMEOUT */
+
+#ifndef ETH_MDIO_BUS_TIMEOUT
+#define ETH_MDIO_BUS_TIMEOUT    ((uint32_t)1000U)
+#endif /* ETH_MDIO_BUS_TIMEOUT */
+
+#ifndef ETH_MAC_US_TICK
+#define ETH_MAC_US_TICK       ((uint32_t)1000000U)
+#endif /* ETH_MAC_US_TICK */
 
 /*********************** Descriptors struct def section ************************/
 /** @defgroup ETH_Exported_Types ETH Exported Types
   * @{
   */
 
-/** 
+/**
   * @brief  ETH DMA Descriptor structure definition
   */
 typedef struct
@@ -64,180 +75,180 @@ typedef struct
   __IO uint32_t DESC3;
   uint32_t BackupAddr0; /* used to store rx buffer 1 address */
   uint32_t BackupAddr1; /* used to store rx buffer 2 address */
-}ETH_DMADescTypeDef;
-/** 
-  * 
+} ETH_DMADescTypeDef;
+/**
+  *
   */
 
-/** 
+/**
   * @brief  ETH Buffers List structure definition
   */
 typedef struct __ETH_BufferTypeDef
 {
   uint8_t *buffer;                /*<! buffer address */
-  
+
   uint32_t len;                   /*<! buffer length */
-  
-  struct __ETH_BufferTypeDef *next; /*<! Pointer to the next buffer in the list */	
-}ETH_BufferTypeDef;
-/** 
-  * 
+
+  struct __ETH_BufferTypeDef *next; /*<! Pointer to the next buffer in the list */
+} ETH_BufferTypeDef;
+/**
+  *
   */
-  
-/** 
+
+/**
   * @brief  DMA Transmit Descriptors Wrapper structure definition
   */
 typedef struct
 {
   uint32_t  TxDesc[ETH_TX_DESC_CNT];        /*<! Tx DMA descriptors addresses */
-  
+
   uint32_t  CurTxDesc;                      /*<! Current Tx descriptor index for packet transmission */
 
-  uint32_t* PacketAddress[ETH_TX_DESC_CNT];  /*<! Ethernet packet addresses array */
+  uint32_t *PacketAddress[ETH_TX_DESC_CNT];  /*<! Ethernet packet addresses array */
 
-  uint32_t* CurrentPacketAddress;           /*<! Current transmit NX_PACKET addresses */
+  uint32_t *CurrentPacketAddress;           /*<! Current transmit NX_PACKET addresses */
 
   uint32_t BuffersInUse;                   /*<! Buffers in Use */
-}ETH_TxDescListTypeDef;
-/** 
-  * 
+
+  uint32_t releaseIndex;                  /*<! Release index */
+} ETH_TxDescListTypeDef;
+/**
+  *
   */
 
- /** 
+/**
   * @brief  Transmit Packet Configuration structure definition
   */
 typedef struct
 {
-  uint32_t Attributes;              /*!< Tx packet HW features capabilities. 
+  uint32_t Attributes;              /*!< Tx packet HW features capabilities.
                                          This parameter can be a combination of @ref ETH_Tx_Packet_Attributes*/
-  
+
   uint32_t Length;                  /*!< Total packet length   */
-  
+
   ETH_BufferTypeDef *TxBuffer;      /*!< Tx buffers pointers */
-  
+
   uint32_t SrcAddrCtrl;             /*!< Specifies the source address insertion control.
                                          This parameter can be a value of @ref ETH_Tx_Packet_Source_Addr_Control */
-  
-  uint32_t CRCPadCtrl;             /*!< Specifies the CRC and Pad insertion and replacement control. 
+
+  uint32_t CRCPadCtrl;             /*!< Specifies the CRC and Pad insertion and replacement control.
                                         This parameter can be a value of @ref ETH_Tx_Packet_CRC_Pad_Control  */
-  
-  uint32_t ChecksumCtrl;           /*!< Specifies the checksum insertion control. 
+
+  uint32_t ChecksumCtrl;           /*!< Specifies the checksum insertion control.
                                         This parameter can be a value of @ref ETH_Tx_Packet_Checksum_Control  */
-  
-  uint32_t MaxSegmentSize;         /*!< Sets TCP maximum segment size only when TCP segmentation is enabled. 
+
+  uint32_t MaxSegmentSize;         /*!< Sets TCP maximum segment size only when TCP segmentation is enabled.
                                         This parameter can be a value from 0x0 to 0x3FFF */
-  
-  uint32_t PayloadLen;             /*!< Sets Total payload length only when TCP segmentation is enabled.     
+
+  uint32_t PayloadLen;             /*!< Sets Total payload length only when TCP segmentation is enabled.
                                         This parameter can be a value from 0x0 to 0x3FFFF */
-  
+
   uint32_t TCPHeaderLen;           /*!< Sets TCP header length only when TCP segmentation is enabled.
                                         This parameter can be a value from 0x5 to 0xF */
 
-  uint32_t VlanTag;                /*!< Sets VLAN Tag only when VLAN is enabled. 
+  uint32_t VlanTag;                /*!< Sets VLAN Tag only when VLAN is enabled.
                                         This parameter can be a value from 0x0 to 0xFFFF*/
-  
-  uint32_t VlanCtrl;               /*!< Specifies VLAN Tag insertion control only when VLAN is enabled. 
+
+  uint32_t VlanCtrl;               /*!< Specifies VLAN Tag insertion control only when VLAN is enabled.
                                         This parameter can be a value of @ref ETH_Tx_Packet_VLAN_Control */
-  
+
   uint32_t InnerVlanTag;           /*!< Sets Inner VLAN Tag only when Inner VLAN is enabled.
                                         This parameter can be a value from 0x0 to 0x3FFFF */
-  
-  uint32_t InnerVlanCtrl;          /*!< Specifies Inner VLAN Tag insertion control only when Inner VLAN is enabled. 
+
+  uint32_t InnerVlanCtrl;          /*!< Specifies Inner VLAN Tag insertion control only when Inner VLAN is enabled.
                                         This parameter can be a value of @ref ETH_Tx_Packet_Inner_VLAN_Control   */
-  
-}ETH_TxPacketConfig;
-/** 
-  * 
+
+  void *pData;                     /*!< Specifies Application packet pointer to save   */
+
+} ETH_TxPacketConfig;
+/**
+  *
   */
 
-/** 
- * @brief  DMA Receive Descriptors Wrapper structure definition
- */
+/**
+  * @brief  ETH Timestamp structure definition
+  */
+typedef struct
+{
+  uint32_t TimeStampLow;
+  uint32_t TimeStampHigh;
+
+} ETH_TimeStampTypeDef;
+/**
+  *
+  */
+
+/**
+  * @brief  ETH Timeupdate structure definition
+  */
+typedef struct
+{
+  uint32_t Seconds;
+  uint32_t NanoSeconds;
+} ETH_TimeTypeDef;
+/**
+  *
+  */
+
+/**
+  * @brief  DMA Receive Descriptors Wrapper structure definition
+  */
 typedef struct
 {
   uint32_t RxDesc[ETH_RX_DESC_CNT];     /*<! Rx DMA descriptors addresses. */
-  
-  uint32_t CurRxDesc;                   /*<! Current Rx descriptor, ready for next reception. */
-  
-  uint32_t FirstAppDesc;                /*<! First descriptor of last received packet. */
-  
-  uint32_t AppDescNbr;                  /*<! Number of descriptors of last received packet. */
- 
-  uint32_t AppContextDesc;              /*<! If 1 a context descriptor is present in last received packet.
-                                             If 0 no context descriptor is present in last received packet. */
-  
+
   uint32_t ItMode;                      /*<! If 1, DMA will generate the Rx complete interrupt.
-                                             If 0, DMA will not generate the Rx complete interrupt. */ 
-}ETH_RxDescListTypeDef;
-/** 
-  * 
+                                             If 0, DMA will not generate the Rx complete interrupt. */
+
+  uint32_t RxDescIdx;                 /*<! Current Rx descriptor. */
+
+  uint32_t RxDescCnt;                 /*<! Number of descriptors . */
+
+  uint32_t RxDataLength;              /*<! Received Data Length. */
+
+  uint32_t RxBuildDescIdx;            /*<! Current Rx Descriptor for building descriptors. */
+
+  uint32_t RxBuildDescCnt;            /*<! Number of Rx Descriptors awaiting building. */
+
+  uint32_t pRxLastRxDesc;             /*<! Last received descriptor. */
+
+  ETH_TimeStampTypeDef TimeStamp;     /*<! Time Stamp Low value for receive. */
+
+  void *pRxStart;                     /*<! Pointer to the first buff. */
+
+  void *pRxEnd;                       /*<! Pointer to the last buff. */
+
+} ETH_RxDescListTypeDef;
+/**
+  *
   */
 
-/** 
-  * @brief  Received Packet Information structure definition
-  */ 
-typedef struct  
-{  
-  uint32_t SegmentCnt;      /*<! Number of Rx Descriptors */
-  
-  uint32_t VlanTag;         /*<! Vlan Tag value */
-  
-  uint32_t InnerVlanTag;    /*<! Inner Vlan Tag value */
-  
-  uint32_t Checksum;        /*<! Rx Checksum status. 
-                                 This parameter can be a value of @ref ETH_Rx_Checksum_Status */
-  
-  uint32_t HeaderType;      /*<! IP header type. 
-                                 This parameter can be a value of @ref ETH_Rx_IP_Header_Type */
-  
-  uint32_t PayloadType;     /*<! Payload type. 
-                                 This parameter can be a value of @ref ETH_Rx_Payload_Type */
-  
-  uint32_t MacFilterStatus; /*<! MAC filter status.  
-                                 This parameter can be a value of @ref ETH_Rx_MAC_Filter_Status */
-  
-  uint32_t L3FilterStatus;  /*<! L3 filter status
-                                 This parameter can be a value of @ref ETH_Rx_L3_Filter_Status */
-  
-  uint32_t L4FilterStatus;  /*<! L4 filter status  
-                                 This parameter can be a value of @ref ETH_Rx_L4_Filter_Status */
-  
-  uint32_t ErrorCode;       /*<! Rx error code  
-                                 This parameter can be a combination of @ref ETH_Rx_Error_Code */
-
-} ETH_RxPacketInfo;
-/** 
-  * 
-  */
-
-/** 
-  * @brief  ETH MAC Configuration Structure definition  
+/**
+  * @brief  ETH MAC Configuration Structure definition
   */
 typedef struct
 {
-  uint32_t         SourceAddrControl;           /*!< Selects the Source Address Insertion or Replacement Control.                                                           
-                                                     This parameter can be a value of @ref ETH_Source_Addr_Control */                  
+  uint32_t
+  SourceAddrControl;           /*!< Selects the Source Address Insertion or Replacement Control.
+                                                     This parameter can be a value of @ref ETH_Source_Addr_Control */
 
-  FunctionalState  ChecksumOffload;             /*!< Enables or Disable the checksum checking for received packet payloads TCP, UDP or ICMP headers */    
+  FunctionalState
+  ChecksumOffload;             /*!< Enables or Disable the checksum checking for received packet payloads TCP, UDP or ICMP headers */
 
   uint32_t         InterPacketGapVal;           /*!< Sets the minimum IPG between Packet during transmission.
-                                                     This parameter can be a value of @ref ETH_Inter_Packet_Gap */   
+                                                     This parameter can be a value of @ref ETH_Inter_Packet_Gap */
 
-  FunctionalState  GiantPacketSizeLimitControl; /*!< Enables or disables the Giant Packet Size Limit Control. */  
+  FunctionalState  GiantPacketSizeLimitControl; /*!< Enables or disables the Giant Packet Size Limit Control. */
 
-  FunctionalState  Support2KPacket;             /*!< Enables or disables the IEEE 802.3as Support for 2K length Packets */ 
+  FunctionalState  Support2KPacket;             /*!< Enables or disables the IEEE 802.3as Support for 2K length Packets */
 
-  FunctionalState  CRCStripTypePacket;          /*!< Enables or disables the CRC stripping for Type packets.*/ 
+  FunctionalState  CRCStripTypePacket;          /*!< Enables or disables the CRC stripping for Type packets.*/
 
-  FunctionalState  AutomaticPadCRCStrip;        /*!< Enables or disables  the Automatic MAC Pad/CRC Stripping.*/ 
-																													 
-  FunctionalState  Watchdog;                    /*!< Enables or disables the Watchdog timer on Rx path
-                                                           When enabled, the MAC allows no more then 2048 bytes to be received.
-                                                           When disabled, the MAC can receive up to 16384 bytes. */  
+  FunctionalState  AutomaticPadCRCStrip;        /*!< Enables or disables  the Automatic MAC Pad/CRC Stripping.*/
 
-  FunctionalState  Jabber;                      /*!< Enables or disables Jabber timer on Tx path
-                                                           When enabled, the MAC allows no more then 2048 bytes to be sent.
-                                                           When disabled, the MAC can send up to 16384 bytes. */
+  FunctionalState  Watchdog;                    /*!< Enables or disables the Watchdog timer on Rx path.*/
+
+  FunctionalState  Jabber;                      /*!< Enables or disables Jabber timer on Tx path.*/
 
   FunctionalState  JumboPacket;                 /*!< Enables or disables receiving Jumbo Packet
                                                            When enabled, the MAC allows jumbo packets of 9,018 bytes
@@ -251,217 +262,328 @@ typedef struct
 
   FunctionalState  LoopbackMode;                /*!< Enables or disables the loopback mode */
 
-  FunctionalState  CarrierSenseBeforeTransmit;  /*!< Enables or disables the Carrier Sense Before Transmission in Full Duplex Mode. */
+  FunctionalState
+  CarrierSenseBeforeTransmit;  /*!< Enables or disables the Carrier Sense Before Transmission in Full Duplex Mode. */
 
-  FunctionalState  ReceiveOwn;                  /*!< Enables or disables the Receive Own in Half Duplex mode. */  
+  FunctionalState  ReceiveOwn;                  /*!< Enables or disables the Receive Own in Half Duplex mode. */
 
-  FunctionalState  CarrierSenseDuringTransmit;  /*!< Enables or disables the Carrier Sense During Transmission in the Half Duplex mode */
+  FunctionalState
+  CarrierSenseDuringTransmit;  /*!< Enables or disables the Carrier Sense During Transmission in the Half Duplex mode */
 
-  FunctionalState  RetryTransmission;           /*!< Enables or disables the MAC retry transmission, when a collision occurs in Half Duplex mode.*/
+  FunctionalState
+  RetryTransmission;           /*!< Enables or disables the MAC retry transmission, when a collision occurs in Half Duplex mode.*/
 
   uint32_t         BackOffLimit;                /*!< Selects the BackOff limit value.
                                                         This parameter can be a value of @ref ETH_Back_Off_Limit */
 
-  FunctionalState  DeferralCheck;               /*!< Enables or disables the deferral check function in Half Duplex mode. */
+  FunctionalState
+  DeferralCheck;               /*!< Enables or disables the deferral check function in Half Duplex mode. */
 
-  uint32_t         PreambleLength;              /*!< Selects or not the Preamble Length for Transmit packets (Full Duplex mode).
-                                                           This parameter can be a value of @ref ETH_Preamble_Length */ 
-                                                           
-  FunctionalState  UnicastSlowProtocolPacketDetect;   /*!< Enable or disables the Detection of Slow Protocol Packets with unicast address. */   
+  uint32_t
+  PreambleLength;              /*!< Selects or not the Preamble Length for Transmit packets (Full Duplex mode).
+                                                           This parameter can be a value of @ref ETH_Preamble_Length */
 
-  FunctionalState  SlowProtocolDetect;          /*!< Enable or disables the Slow Protocol Detection. */   
+  FunctionalState
+  UnicastSlowProtocolPacketDetect;   /*!< Enable or disables the Detection of Slow Protocol Packets with unicast address. */
 
-  FunctionalState  CRCCheckingRxPackets;        /*!< Enable or disables the CRC Checking for Received Packets. */   
+  FunctionalState  SlowProtocolDetect;          /*!< Enable or disables the Slow Protocol Detection. */
 
-  uint32_t         GiantPacketSizeLimit;        /*!< Specifies the packet size that the MAC will declare it as Giant, If it's size is 
-	                                                  greater than the value programmed in this field in units of bytes 
-                                                          This parameter must be a number between Min_Data = 0x618 (1518 byte) and Max_Data = 0x3FFF (32 Kbyte)*/                                                          
- 
-  FunctionalState  ExtendedInterPacketGap;      /*!< Enable or disables the extended inter packet gap. */ 
-  
+  FunctionalState  CRCCheckingRxPackets;        /*!< Enable or disables the CRC Checking for Received Packets. */
+
+  uint32_t
+  GiantPacketSizeLimit;        /*!< Specifies the packet size that the MAC will declare it as Giant, If it's size is
+                                                    greater than the value programmed in this field in units of bytes
+                                                    This parameter must be a number between
+                                                    Min_Data = 0x618 (1518 byte) and Max_Data = 0x3FFF (32 Kbyte). */
+
+  FunctionalState  ExtendedInterPacketGap;      /*!< Enable or disables the extended inter packet gap. */
+
   uint32_t         ExtendedInterPacketGapVal;   /*!< Sets the Extended IPG between Packet during transmission.
-                                                           This parameter can be a value from 0x0 to 0xFF */ 
-  
+                                                           This parameter can be a value from 0x0 to 0xFF */
+
   FunctionalState  ProgrammableWatchdog;        /*!< Enable or disables the Programmable Watchdog.*/
-	
+
   uint32_t         WatchdogTimeout;             /*!< This field is used as watchdog timeout for a received packet
-                                                        This parameter can be a value of @ref ETH_Watchdog_Timeout */                                                            
+                                                        This parameter can be a value of @ref ETH_Watchdog_Timeout */
 
-   uint32_t        PauseTime;                   /*!< This field holds the value to be used in the Pause Time field in the transmit control packet. 
-                                                   This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
+  uint32_t
+  PauseTime;                   /*!< This field holds the value to be used in the Pause Time field in the transmit control packet.
+                                                   This parameter must be a number between
+                                                   Min_Data = 0x0 and Max_Data = 0xFFFF.*/
 
-  FunctionalState  ZeroQuantaPause;             /*!< Enable or disables the automatic generation of Zero Quanta Pause Control packets.*/  
+  FunctionalState
+  ZeroQuantaPause;             /*!< Enable or disables the automatic generation of Zero Quanta Pause Control packets.*/
 
-  uint32_t         PauseLowThreshold;           /*!< This field configures the threshold of the PAUSE to be checked for automatic retransmission of PAUSE Packet.
+  uint32_t
+  PauseLowThreshold;           /*!< This field configures the threshold of the PAUSE to be checked for automatic retransmission of PAUSE Packet.
                                                    This parameter can be a value of @ref ETH_Pause_Low_Threshold */
 
-  FunctionalState  TransmitFlowControl;         /*!< Enables or disables the MAC to transmit Pause packets in Full Duplex mode
+  FunctionalState
+  TransmitFlowControl;         /*!< Enables or disables the MAC to transmit Pause packets in Full Duplex mode
                                                    or the MAC back pressure operation in Half Duplex mode */
 
-  FunctionalState  UnicastPausePacketDetect;    /*!< Enables or disables the MAC to detect Pause packets with unicast address of the station */
-  
-  FunctionalState  ReceiveFlowControl;          /*!< Enables or disables the MAC to decodes the received Pause packet  
+  FunctionalState
+  UnicastPausePacketDetect;    /*!< Enables or disables the MAC to detect Pause packets with unicast address of the station */
+
+  FunctionalState  ReceiveFlowControl;          /*!< Enables or disables the MAC to decodes the received Pause packet
                                                   and disables its transmitter for a specified (Pause) time */
-																													                                                        	 
+
   uint32_t         TransmitQueueMode;           /*!< Specifies the Transmit Queue operating mode.
-                                                      This parameter can be a value of @ref ETH_Transmit_Mode */ 
+                                                      This parameter can be a value of @ref ETH_Transmit_Mode */
 
   uint32_t         ReceiveQueueMode;            /*!< Specifies the Receive Queue operating mode.
                                                              This parameter can be a value of @ref ETH_Receive_Mode */
 
-  FunctionalState  DropTCPIPChecksumErrorPacket; /*!< Enables or disables Dropping of TCPIP Checksum Error Packets. */ 
+  FunctionalState  DropTCPIPChecksumErrorPacket; /*!< Enables or disables Dropping of TCPIP Checksum Error Packets. */
 
-  FunctionalState  ForwardRxErrorPacket;        /*!< Enables or disables  forwarding Error Packets. */ 
+  FunctionalState  ForwardRxErrorPacket;        /*!< Enables or disables  forwarding Error Packets. */
 
-  FunctionalState  ForwardRxUndersizedGoodPacket;  /*!< Enables or disables  forwarding Undersized Good Packets.*/ 
+  FunctionalState  ForwardRxUndersizedGoodPacket;  /*!< Enables or disables  forwarding Undersized Good Packets.*/
 } ETH_MACConfigTypeDef;
-/** 
-  * 
+/**
+  *
   */
 
-/** 
-  * @brief  ETH DMA Configuration Structure definition  
+/**
+  * @brief  ETH DMA Configuration Structure definition
   */
- typedef struct
- {
-   uint32_t        DMAArbitration;          /*!< Sets the arbitration scheme between DMA Tx and Rx
+typedef struct
+{
+  uint32_t        DMAArbitration;          /*!< Sets the arbitration scheme between DMA Tx and Rx
                                                          This parameter can be a value of @ref ETH_DMA_Arbitration */
-      
-   FunctionalState AddressAlignedBeats;     /*!< Enables or disables the AHB Master interface address aligned 
+
+  FunctionalState AddressAlignedBeats;     /*!< Enables or disables the AHB Master interface address aligned
                                                             burst transfers on Read and Write channels  */
-      
-   uint32_t        BurstMode;               /*!< Sets the AHB Master interface burst transfers.
+
+  uint32_t        BurstMode;               /*!< Sets the AHB Master interface burst transfers.
                                                      This parameter can be a value of @ref ETH_Burst_Mode */
-      
-   FunctionalState RebuildINCRxBurst;       /*!< Enables or disables the AHB Master to rebuild the pending beats 
+
+  FunctionalState RebuildINCRxBurst;       /*!< Enables or disables the AHB Master to rebuild the pending beats
                                                    of any initiated burst transfer with INCRx and SINGLE transfers. */
-      
-   FunctionalState PBLx8Mode;               /*!< Enables or disables the PBL multiplication by eight. */
-      
-   uint32_t        TxDMABurstLength;        /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
-                                                     This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */	
-      
-   FunctionalState SecondPacketOperate;     /*!< Enables or disables the Operate on second Packet mode, which allows the DMA to process a second
-                                                      Packet of Transmit data even before obtaining the status for the first one. */	
-      
-   uint32_t        RxDMABurstLength;        /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
+
+  FunctionalState PBLx8Mode;               /*!< Enables or disables the PBL multiplication by eight. */
+
+  uint32_t
+  TxDMABurstLength;        /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
+                                                     This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
+
+  FunctionalState
+  SecondPacketOperate;     /*!< Enables or disables the Operate on second Packet mode, which allows the DMA to process a second
+                                                      Packet of Transmit data even before
+                                                      obtaining the status for the first one. */
+
+  uint32_t
+  RxDMABurstLength;        /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
                                                     This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
-      
-   FunctionalState FlushRxPacket;           /*!< Enables or disables the Rx Packet Flush */
-      
-   FunctionalState TCPSegmentation;         /*!< Enables or disables the TCP Segmentation */
-      
-   uint32_t        MaximumSegmentSize;      /*!< Sets the maximum segment size that should be used while segmenting the packet
-                                                  This parameter can be a value from 0x40 to 0x3FFF */    
+
+  FunctionalState FlushRxPacket;           /*!< Enables or disables the Rx Packet Flush */
+
+  FunctionalState TCPSegmentation;         /*!< Enables or disables the TCP Segmentation */
+
+  uint32_t
+  MaximumSegmentSize;      /*!< Sets the maximum segment size that should be used while segmenting the packet
+                                                  This parameter can be a value from 0x40 to 0x3FFF */
 } ETH_DMAConfigTypeDef;
-/** 
-  * 
+/**
+  *
   */
 
-/** 
-  * @brief  HAL ETH Media Interfaces enum definition  
-  */ 
+/**
+  * @brief  HAL ETH Media Interfaces enum definition
+  */
 typedef enum
 {
   HAL_ETH_MII_MODE             = 0x00U,   /*!<  Media Independent Interface               */
   HAL_ETH_RMII_MODE            = 0x01U    /*!<   Reduced Media Independent Interface       */
-}ETH_MediaInterfaceTypeDef;
-/** 
-  * 
+} ETH_MediaInterfaceTypeDef;
+/**
+  *
   */
 
-/** 
-  * @brief  ETH Init Structure definition  
+/**
+  * @brief  HAL ETH PTP Update type enum definition
+  */
+typedef enum
+{
+  HAL_ETH_PTP_POSITIVE_UPDATE   = 0x00000000U,   /*!<  PTP positive time update       */
+  HAL_ETH_PTP_NEGATIVE_UPDATE   = 0x00000001U   /*!<  PTP negative time update       */
+} ETH_PtpUpdateTypeDef;
+/**
+  *
+  */
+
+/**
+  * @brief  ETH Init Structure definition
   */
 typedef struct
 {
-   
-  uint8_t                     *MACAddr;                  /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
-  	
+
+  uint8_t
+  *MACAddr;                  /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
+
   ETH_MediaInterfaceTypeDef   MediaInterface;            /*!< Selects the MII interface or the RMII interface. */
 
-  ETH_DMADescTypeDef          *TxDesc;                   /*!< Provides the address of the first DMA Tx descriptor in the list */
-  
-  ETH_DMADescTypeDef          *RxDesc;                   /*!< Provides the address of the first DMA Rx descriptor in the list */
-  
+  ETH_DMADescTypeDef
+  *TxDesc;                   /*!< Provides the address of the first DMA Tx descriptor in the list */
+
+  ETH_DMADescTypeDef
+  *RxDesc;                   /*!< Provides the address of the first DMA Rx descriptor in the list */
+
   uint32_t                    RxBuffLen;                 /*!< Provides the length of Rx buffers size */
 
-}ETH_InitTypeDef;
-/** 
-  * 
+} ETH_InitTypeDef;
+/**
+  *
   */
 
-/** 
-  * @brief  HAL State structures definition  
-  */ 
+/**
+  * @brief  ETH PTP Init Structure definition
+  */
+typedef struct
+{
+  uint32_t                    Timestamp;                    /*!< Enable Timestamp */
+  uint32_t                    TimestampUpdateMode;          /*!< Fine or Coarse Timestamp Update */
+  uint32_t                    TimestampInitialize;          /*!< Initialize Timestamp */
+  uint32_t                    TimestampUpdate;              /*!< Timestamp Update */
+  uint32_t                    TimestampAddendUpdate;        /*!< Timestamp Addend Update */
+  uint32_t                    TimestampAll;                 /*!< Enable Timestamp for All Packets */
+  uint32_t                    TimestampRolloverMode;        /*!< Timestamp Digital or Binary Rollover Control */
+  uint32_t                    TimestampV2;                  /*!< Enable PTP Packet Processing for Version 2 Format */
+  uint32_t                    TimestampEthernet;            /*!< Enable Processing of PTP over Ethernet Packets */
+  uint32_t                    TimestampIPv6;                /*!< Enable Processing of PTP Packets Sent over IPv6-UDP */
+  uint32_t                    TimestampIPv4;                /*!< Enable Processing of PTP Packets Sent over IPv4-UDP */
+  uint32_t                    TimestampEvent;               /*!< Enable Timestamp Snapshot for Event Messages */
+  uint32_t                    TimestampMaster;              /*!< Enable Timestamp Snapshot for Event Messages */
+  uint32_t                    TimestampSnapshots;           /*!< Select PTP packets for Taking Snapshots */
+  uint32_t                    TimestampFilter;              /*!< Enable MAC Address for PTP Packet Filtering */
+  uint32_t
+  TimestampChecksumCorrection;  /*!< Enable checksum correction during OST for PTP over UDP/IPv4 packets */
+  uint32_t                    TimestampStatusMode;          /*!< Transmit Timestamp Status Mode */
+  uint32_t                    TimestampAddend;              /*!< Timestamp addend value */
+  uint32_t                    TimestampSubsecondInc;        /*!< Subsecond Increment */
+
+} ETH_PTP_ConfigTypeDef;
+/**
+  *
+  */
+
+/**
+  * @brief  HAL State structures definition
+  */
 typedef uint32_t HAL_ETH_StateTypeDef;
-/** 
-  * 
+/**
+  *
   */
 
-/** 
-  * @brief  ETH Handle Structure definition  
+/**
+  * @brief  HAL ETH Rx Get Buffer Function definition
+  */
+typedef  void (*pETH_rxAllocateCallbackTypeDef)(uint8_t **buffer);  /*!< pointer to an ETH Rx Get Buffer Function */
+/**
+  *
+  */
+
+/**
+  * @brief  HAL ETH Rx Set App Data Function definition
+  */
+typedef  void (*pETH_rxLinkCallbackTypeDef)(void **pStart, void **pEnd, uint8_t *buff,
+                                            uint16_t Length); /*!< pointer to an ETH Rx Set App Data Function */
+/**
+  *
+  */
+
+/**
+  * @brief  HAL ETH Tx Free Function definition
+  */
+typedef  void (*pETH_txFreeCallbackTypeDef)(uint32_t *buffer);  /*!< pointer to an ETH Tx Free function */
+/**
+  *
+  */
+
+/**
+  * @brief  HAL ETH Tx Free Function definition
+  */
+typedef  void (*pETH_txPtpCallbackTypeDef)(uint32_t *buffer,
+                                           ETH_TimeStampTypeDef *timestamp);  /*!< pointer to an ETH Tx Free function */
+/**
+  *
+  */
+
+/**
+  * @brief  ETH Handle Structure definition
   */
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
 typedef struct __ETH_HandleTypeDef
 #else
 typedef struct
-#endif
+#endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
 {
   ETH_TypeDef                *Instance;                 /*!< Register base address       */
-  
+
   ETH_InitTypeDef            Init;                      /*!< Ethernet Init Configuration */
-	
-  ETH_TxDescListTypeDef      TxDescList;                /*!< Tx descriptor wrapper: holds all Tx descriptors list 
+
+  ETH_TxDescListTypeDef      TxDescList;                /*!< Tx descriptor wrapper: holds all Tx descriptors list
                                                             addresses and current descriptor index  */
-		
-  ETH_RxDescListTypeDef      RxDescList;                /*!< Rx descriptor wrapper: holds all Rx descriptors list 
-                                                            addresses and current descriptor index  */ 
-  
-  HAL_LockTypeDef            Lock;                      /*!< Locking object             */
- 
-  __IO HAL_ETH_StateTypeDef  gState;                   /*!< ETH state information related to global Handle management 
-                                                              and also related to Tx operations.
-                                                             This parameter can be a value of @ref HAL_ETH_StateTypeDef */
-  
-  __IO HAL_ETH_StateTypeDef  RxState;                   /*!< ETH state information related to Rx operations.
-                                                             This parameter can be a value of @ref HAL_ETH_StateTypeDef */
-  
-  __IO uint32_t              ErrorCode;                 /*!< Holds the global Error code of the ETH HAL status machine 
-                                                             This parameter can be a value of of @ref ETH_Error_Code */
-  
-  __IO uint32_t              DMAErrorCode;              /*!< Holds the DMA Rx Tx Error code when a DMA AIS interrupt occurs
-                                                             This parameter can be a combination of @ref ETH_DMA_Status_Flags */
-  
-  __IO uint32_t              MACErrorCode;              /*!< Holds the MAC Rx Tx Error code when a MAC Rx or Tx status interrupt occurs
-                                                             This parameter can be a combination of @ref ETH_MAC_Rx_Tx_Status */ 
-    
+
+  ETH_RxDescListTypeDef      RxDescList;                /*!< Rx descriptor wrapper: holds all Rx descriptors list
+                                                            addresses and current descriptor index  */
+
+#ifdef HAL_ETH_USE_PTP
+  ETH_TimeStampTypeDef       TxTimestamp;               /*!< Tx Timestamp */
+#endif /* HAL_ETH_USE_PTP */
+
+  __IO HAL_ETH_StateTypeDef  gState;                   /*!< ETH state information related to global Handle management
+                                                              and also related to Tx operations. This parameter can
+                                                              be a value of @ref HAL_ETH_StateTypeDef */
+
+  __IO uint32_t              ErrorCode;                 /*!< Holds the global Error code of the ETH HAL status machine
+                                                             This parameter can be a value of @ref ETH_Error_Code.*/
+
+  __IO uint32_t
+  DMAErrorCode;              /*!< Holds the DMA Rx Tx Error code when a DMA AIS interrupt occurs
+                                                             This parameter can be a combination of
+                                                             @ref ETH_DMA_Status_Flags */
+
+  __IO uint32_t
+  MACErrorCode;              /*!< Holds the MAC Rx Tx Error code when a MAC Rx or Tx status interrupt occurs
+                                                             This parameter can be a combination of
+                                                             @ref ETH_MAC_Rx_Tx_Status */
+
   __IO uint32_t              MACWakeUpEvent;            /*!< Holds the Wake Up event when the MAC exit the power down mode
-                                                             This parameter can be a value of @ref ETH_MAC_Wake_Up_Event */
-    
+                                                             This parameter can be a value of
+                                                             @ref ETH_MAC_Wake_Up_Event */
+
   __IO uint32_t              MACLPIEvent;               /*!< Holds the LPI event when the an LPI status interrupt occurs.
                                                              This parameter can be a value of @ref ETHEx_LPI_Event */
-                                                             
+
+  __IO uint32_t              IsPtpConfigured;           /*!< Holds the PTP configuration status.
+                                                             This parameter can be a value of
+                                                             @ref ETH_PTP_Config_Status */
+
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
 
-  void    (* TxCpltCallback)     ( struct __ETH_HandleTypeDef * heth);   /*!< ETH Tx Complete Callback */
-  void    (* RxCpltCallback)     ( struct __ETH_HandleTypeDef * heth);  /*!< ETH Rx  Complete Callback     */
-  void    (* DMAErrorCallback)   ( struct __ETH_HandleTypeDef * heth);  /*!< ETH DMA Error Callback   */
-  void    (* MACErrorCallback)   ( struct __ETH_HandleTypeDef * heth);  /*!< ETH MAC Error Callback     */
-  void    (* PMTCallback)        ( struct __ETH_HandleTypeDef * heth);  /*!< ETH Power Management Callback            */
-  void    (* EEECallback)        ( struct __ETH_HandleTypeDef * heth);  /*!< ETH EEE Callback   */
-  void    (* WakeUpCallback)     ( struct __ETH_HandleTypeDef * heth);  /*!< ETH Wake UP Callback   */
+  void (* TxCpltCallback)(struct __ETH_HandleTypeDef *heth);             /*!< ETH Tx Complete Callback */
+  void (* RxCpltCallback)(struct __ETH_HandleTypeDef *heth);            /*!< ETH Rx  Complete Callback     */
+  void (* ErrorCallback)(struct __ETH_HandleTypeDef *heth);             /*!< ETH Error Callback   */
+  void (* PMTCallback)(struct __ETH_HandleTypeDef *heth);               /*!< ETH Power Management Callback            */
+  void (* EEECallback)(struct __ETH_HandleTypeDef *heth);               /*!< ETH EEE Callback   */
+  void (* WakeUpCallback)(struct __ETH_HandleTypeDef *heth);            /*!< ETH Wake UP Callback   */
 
-  void    (* MspInitCallback)    ( struct __ETH_HandleTypeDef * heth);    /*!< ETH Msp Init callback              */
-  void    (* MspDeInitCallback)  ( struct __ETH_HandleTypeDef * heth);    /*!< ETH Msp DeInit callback            */
+  void (* MspInitCallback)(struct __ETH_HandleTypeDef *heth);             /*!< ETH Msp Init callback              */
+  void (* MspDeInitCallback)(struct __ETH_HandleTypeDef *heth);           /*!< ETH Msp DeInit callback            */
 
-#endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */                                                             
+#endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
+
+  pETH_rxAllocateCallbackTypeDef  rxAllocateCallback;  /*!< ETH Rx Get Buffer Function   */
+  pETH_rxLinkCallbackTypeDef      rxLinkCallback; /*!< ETH Rx Set App Data Function */
+  pETH_txFreeCallbackTypeDef      txFreeCallback;       /*!< ETH Tx Free Function         */
+  pETH_txPtpCallbackTypeDef       txPtpCallback;  /*!< ETH Tx Handle Ptp Function */
 
 } ETH_HandleTypeDef;
-/** 
-  * 
+/**
+  *
   */
-  
+
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
 /**
   * @brief  HAL ETH Callback ID enumeration definition
@@ -470,73 +592,74 @@ typedef enum
 {
   HAL_ETH_MSPINIT_CB_ID            = 0x00U,    /*!< ETH MspInit callback ID           */
   HAL_ETH_MSPDEINIT_CB_ID          = 0x01U,    /*!< ETH MspDeInit callback ID         */
-	
+
   HAL_ETH_TX_COMPLETE_CB_ID        = 0x02U,    /*!< ETH Tx Complete Callback ID       */
   HAL_ETH_RX_COMPLETE_CB_ID        = 0x03U,    /*!< ETH Rx Complete Callback ID       */
-  HAL_ETH_DMA_ERROR_CB_ID          = 0x04U,    /*!< ETH DMA Error Callback ID         */
-  HAL_ETH_MAC_ERROR_CB_ID          = 0x05U,    /*!< ETH MAC Error Callback ID         */
-  HAL_ETH_PMT_CB_ID                = 0x06U,     /*!< ETH Power Management Callback ID  */
-  HAL_ETH_EEE_CB_ID                = 0x07U,     /*!< ETH EEE Callback ID               */
+  HAL_ETH_ERROR_CB_ID              = 0x04U,    /*!< ETH Error Callback ID             */
+  HAL_ETH_PMT_CB_ID                = 0x06U,    /*!< ETH Power Management Callback ID  */
+  HAL_ETH_EEE_CB_ID                = 0x07U,    /*!< ETH EEE Callback ID               */
   HAL_ETH_WAKEUP_CB_ID             = 0x08U     /*!< ETH Wake UP Callback ID           */
 
 
-}HAL_ETH_CallbackIDTypeDef;
+} HAL_ETH_CallbackIDTypeDef;
 
 /**
   * @brief  HAL ETH Callback pointer definition
   */
-typedef  void (*pETH_CallbackTypeDef)(ETH_HandleTypeDef * heth); /*!< pointer to an ETH callback function */
+typedef  void (*pETH_CallbackTypeDef)(ETH_HandleTypeDef *heth);  /*!< pointer to an ETH callback function */
 
 #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
 
-/** 
+/**
   * @brief  ETH MAC filter structure definition
   */
-typedef struct{
+typedef struct
+{
   FunctionalState PromiscuousMode;          /*!< Enable or Disable Promiscuous Mode */
-  
+
   FunctionalState ReceiveAllMode;           /*!< Enable or Disable Receive All Mode */
-  
+
   FunctionalState HachOrPerfectFilter;      /*!< Enable or Disable Perfect filtering in addition to Hash filtering */
-  
+
   FunctionalState HashUnicast;              /*!< Enable or Disable Hash filtering on unicast packets */
-  
+
   FunctionalState HashMulticast;            /*!< Enable or Disable Hash filtering on multicast packets */
-  
+
   FunctionalState PassAllMulticast;         /*!< Enable or Disable passing all multicast packets */
-  
+
   FunctionalState SrcAddrFiltering;         /*!< Enable or Disable source address filtering module */
-  
+
   FunctionalState SrcAddrInverseFiltering;  /*!< Enable or Disable source address inverse filtering */
-  
+
   FunctionalState DestAddrInverseFiltering; /*!< Enable or Disable destination address inverse filtering */
-  
+
   FunctionalState BroadcastFilter;          /*!< Enable or Disable broadcast filter */
-  
+
   uint32_t        ControlPacketsFilter;     /*!< Set the control packets filter
                                                  This parameter can be a value of @ref ETH_Control_Packets_Filter */
-}ETH_MACFilterConfigTypeDef;
-/** 
-  * 
+} ETH_MACFilterConfigTypeDef;
+/**
+  *
   */
-    
-/** 
+
+/**
   * @brief  ETH Power Down structure definition
   */
-typedef struct{
+typedef struct
+{
   FunctionalState WakeUpPacket;    /*!< Enable or Disable Wake up packet detection in power down mode */
-  
+
   FunctionalState MagicPacket;     /*!< Enable or Disable Magic packet detection in power down mode */
-  
+
   FunctionalState GlobalUnicast;    /*!< Enable or Disable Global unicast packet detection in power down mode */
-  
+
   FunctionalState WakeUpForward;    /*!< Enable or Disable Forwarding Wake up packets */
-  	
-}ETH_PowerDownConfigTypeDef;
-/** 
-  * 
+
+} ETH_PowerDownConfigTypeDef;
+/**
+  *
   */
-  
+
 /**
   * @}
   */
@@ -563,19 +686,19 @@ typedef struct{
   -----------------------------------------------------------------------------------------------
 */
 
-/** 
+/**
   * @brief  Bit definition of TDES0 RF register
-  */ 
+  */
 #define ETH_DMATXNDESCRF_B1AP  ((uint32_t)0xFFFFFFFFU)  /*!< Transmit Packet Timestamp Low */
 
-/** 
+/**
   * @brief  Bit definition of TDES1 RF register
-  */ 
+  */
 #define ETH_DMATXNDESCRF_B2AP  ((uint32_t)0xFFFFFFFFU)  /*!< Transmit Packet Timestamp High */
 
-/** 
+/**
   * @brief  Bit definition of TDES2 RF register
-  */ 
+  */
 #define ETH_DMATXNDESCRF_IOC          ((uint32_t)0x80000000U)  /*!< Interrupt on Completion */
 #define ETH_DMATXNDESCRF_TTSE         ((uint32_t)0x40000000U)  /*!< Transmit Timestamp Enable */
 #define ETH_DMATXNDESCRF_B2L          ((uint32_t)0x3FFF0000U)  /*!< Buffer 2 Length */
@@ -587,9 +710,9 @@ typedef struct{
 #define ETH_DMATXNDESCRF_B1L          ((uint32_t)0x00003FFFU)  /*!< Buffer 1 Length */
 #define ETH_DMATXNDESCRF_HL           ((uint32_t)0x000003FFU)  /*!< Header Length */
 
-/** 
+/**
   * @brief  Bit definition of TDES3 RF register
-  */ 
+  */
 #define ETH_DMATXNDESCRF_OWN                                 ((uint32_t)0x80000000U)  /*!< OWN bit: descriptor is owned by DMA engine */
 #define ETH_DMATXNDESCRF_CTXT                                ((uint32_t)0x40000000U)  /*!< Context Type */
 #define ETH_DMATXNDESCRF_FD                                  ((uint32_t)0x20000000U)  /*!< First Descriptor */
@@ -605,13 +728,17 @@ typedef struct{
 #define ETH_DMATXNDESCRF_SAIC_REPLACE                        ((uint32_t)0x01000000U)  /*!< SA Insertion Control: Replace the source address */
 #define ETH_DMATXNDESCRF_THL                                 ((uint32_t)0x00780000U)  /*!< TCP Header Length */
 #define ETH_DMATXNDESCRF_TSE                                 ((uint32_t)0x00040000U)  /*!< TCP segmentation enable */
-#define ETH_DMATXNDESCRF_CIC                                 ((uint32_t)0x00030000U)  /*!< Checksum Insertion Control: 4 cases */ 
-#define ETH_DMATXNDESCRF_CIC_DISABLE                         ((uint32_t)0x00000000U)  /*!< Do Nothing: Checksum Engine is disabled */ 
-#define ETH_DMATXNDESCRF_CIC_IPHDR_INSERT                    ((uint32_t)0x00010000U)  /*!< Only IP header checksum calculation and insertion are enabled. */ 
+#define ETH_DMATXNDESCRF_CIC                                 ((uint32_t)0x00030000U)  /*!< Checksum Insertion Control: 4 cases */
+#define ETH_DMATXNDESCRF_CIC_DISABLE                         ((uint32_t)0x00000000U)  /*!< Do Nothing: Checksum Engine is disabled */
+#define ETH_DMATXNDESCRF_CIC_IPHDR_INSERT                    ((uint32_t)0x00010000U)  /*!< Only IP header checksum calculation and insertion are enabled. */
 #define ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT            ((uint32_t)0x00020000U)  /*!< IP header checksum and payload checksum calculation and insertion are
-                                                                                          enabled, but pseudo header checksum is not calculated in hardware */ 
+                                                                                          enabled, but pseudo header 
+                                                                                          checksum is not
+                                                                                          calculated in hardware */
 #define ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT_PHDR_CALC  ((uint32_t)0x00030000U)  /*!< IP Header checksum and payload checksum calculation and insertion are
-                                                                                          enabled, and pseudo header checksum is calculated in hardware. */ 
+                                                                                          enabled, and pseudo header 
+                                                                                          checksum is
+                                                                                          calculated in hardware. */
 #define ETH_DMATXNDESCRF_TPL                                 ((uint32_t)0x0003FFFFU)  /*!< TCP Payload Length */
 #define ETH_DMATXNDESCRF_FL                                  ((uint32_t)0x00007FFFU)  /*!< Transmit End of Ring */
 
@@ -628,19 +755,19 @@ typedef struct{
   -----------------------------------------------------------------------------------------------
 */
 
-/** 
+/**
   * @brief  Bit definition of TDES0 WBF register
-  */ 
+  */
 #define ETH_DMATXNDESCWBF_TTSL  ((uint32_t)0xFFFFFFFFU)  /*!< Buffer1 Address Pointer or TSO Header Address Pointer */
 
-/** 
+/**
   * @brief  Bit definition of TDES1 WBF register
-  */ 
+  */
 #define ETH_DMATXNDESCWBF_TTSH  ((uint32_t)0xFFFFFFFFU)  /*!< Buffer2 Address Pointer */
 
-/** 
+/**
   * @brief  Bit definition of TDES3 WBF register
-  */ 
+  */
 #define ETH_DMATXNDESCWBF_OWN                     ((uint32_t)0x80000000U)  /*!< OWN bit: descriptor is owned by DMA engine */
 #define ETH_DMATXNDESCWBF_CTXT                    ((uint32_t)0x40000000U)  /*!< Context Type */
 #define ETH_DMATXNDESCWBF_FD                      ((uint32_t)0x20000000U)  /*!< First Descriptor */
@@ -676,23 +803,23 @@ typedef struct{
   -----------------------------------------------------------------------------------------------
 */
 
-/** 
+/**
   * @brief  Bit definition of Tx context descriptor register 0
-  */ 
+  */
 #define ETH_DMATXCDESC_TTSL  ((uint32_t)0xFFFFFFFFU)  /*!< Transmit Packet Timestamp Low */
 
-/** 
+/**
   * @brief  Bit definition of Tx context descriptor register 1
-  */ 
+  */
 #define ETH_DMATXCDESC_TTSH  ((uint32_t)0xFFFFFFFFU)  /*!< Transmit Packet Timestamp High */
 
-/** 
+/**
   * @brief  Bit definition of Tx context descriptor register 2
-  */ 
+  */
 #define ETH_DMATXCDESC_IVT   ((uint32_t)0xFFFF0000U)  /*!< Inner VLAN Tag */
 #define ETH_DMATXCDESC_MSS   ((uint32_t)0x00003FFFU)  /*!< Maximum Segment Size */
 
-/** 
+/**
   * @brief  Bit definition of Tx context descriptor register 3
   */
 #define ETH_DMATXCDESC_OWN                     ((uint32_t)0x80000000U)     /*!< OWN bit: descriptor is owned by DMA engine */
@@ -711,7 +838,7 @@ typedef struct{
 
 /**
   * @}
-  */ 
+  */
 
 
 /** @defgroup ETH_DMA_Rx_Descriptor_Bit_Definition ETH DMA Rx Descriptor Bit Definition
@@ -731,17 +858,17 @@ typedef struct{
   -----------------------------------------------------------------------------------------------------------
 */
 
-/** 
+/**
   * @brief  Bit definition of Rx normal descriptor register 0 read format
   */
 #define ETH_DMARXNDESCRF_BUF1AP        ((uint32_t)0xFFFFFFFFU)  /*!< Header or Buffer 1 Address Pointer  */
 
-/** 
+/**
   * @brief  Bit definition of Rx normal descriptor register 2 read format
   */
 #define ETH_DMARXNDESCRF_BUF2AP        ((uint32_t)0xFFFFFFFFU)  /*!< Buffer 2 Address Pointer  */
 
-/** 
+/**
   * @brief  Bit definition of Rx normal descriptor register 3 read format
   */
 #define ETH_DMARXNDESCRF_OWN         ((uint32_t)0x80000000U)  /*!< OWN bit: descriptor is owned by DMA engine  */
@@ -752,8 +879,8 @@ typedef struct{
 /*
   DMA Rx Normal Descriptor write back format
   ---------------------------------------------------------------------------------------------------------------------
-  RDES0 |                 Inner VLAN Tag[31:16]                 |                 Outer VLAN Tag[15:0]                | 
-	---------------------------------------------------------------------------------------------------------------------
+  RDES0 |                 Inner VLAN Tag[31:16]                 |                 Outer VLAN Tag[15:0]                |
+  ---------------------------------------------------------------------------------------------------------------------
   RDES1 |       OAM code, or MAC Control Opcode [31:16]         |               Extended Status                       |
   ---------------------------------------------------------------------------------------------------------------------
   RDES2 |      MAC Filter Status[31:16]        | VF(15) | Reserved [14:12] | ARP Status [11:10] | Header Length [9:0] |
@@ -762,13 +889,13 @@ typedef struct{
   ---------------------------------------------------------------------------------------------------------------------
 */
 
-/** 
+/**
   * @brief  Bit definition of Rx normal descriptor register 0 write back format
   */
 #define ETH_DMARXNDESCWBF_IVT        ((uint32_t)0xFFFF0000U)  /*!< Inner VLAN Tag  */
 #define ETH_DMARXNDESCWBF_OVT        ((uint32_t)0x0000FFFFU)  /*!< Outer VLAN Tag  */
 
-/** 
+/**
   * @brief  Bit definition of Rx normal descriptor register 1 write back format
   */
 #define ETH_DMARXNDESCWBF_OPC             ((uint32_t)0xFFFF0000U)  /*!< OAM Sub-Type Code, or MAC Control Packet opcode  */
@@ -799,7 +926,7 @@ typedef struct{
 #define ETH_DMARXNDESCWBF_PT_TCP          ((uint32_t)0x00000002U)  /*!< Payload Type: TCP  */
 #define ETH_DMARXNDESCWBF_PT_ICMP         ((uint32_t)0x00000003U)  /*!< Payload Type: ICMP */
 
-/** 
+/**
   * @brief  Bit definition of Rx normal descriptor register 2 write back format
   */
 #define ETH_DMARXNDESCWBF_L3L4FM          ((uint32_t)0x20000000U)  /*!< L3 and L4 Filter Number Matched: if reset filter 0 is matched , if set filter 1 is matched */
@@ -813,7 +940,7 @@ typedef struct{
 #define ETH_DMARXNDESCWBF_ARPNR           ((uint32_t)0x00000400U)  /*!< ARP Reply Not Generated               */
 
 
-/** 
+/**
   * @brief  Bit definition of Rx normal descriptor register 3 write back format
   */
 #define ETH_DMARXNDESCWBF_OWN        ((uint32_t)0x80000000U)  /*!< Own Bit */
@@ -843,8 +970,8 @@ typedef struct{
 /*
   DMA Rx context Descriptor
   ---------------------------------------------------------------------------------------------------------------------
-  RDES0 |                                     Timestamp Low[31:0]                                                     | 
-	---------------------------------------------------------------------------------------------------------------------
+  RDES0 |                                     Timestamp Low[31:0]                                                     |
+  ---------------------------------------------------------------------------------------------------------------------
   RDES1 |                                     Timestamp High[31:0]                                                    |
   ---------------------------------------------------------------------------------------------------------------------
   RDES2 |                                          Reserved                                                           |
@@ -853,17 +980,17 @@ typedef struct{
   ---------------------------------------------------------------------------------------------------------------------
 */
 
-/** 
-  * @brief  Bit definition of Rx context descriptor register 0 
+/**
+  * @brief  Bit definition of Rx context descriptor register 0
   */
 #define ETH_DMARXCDESC_RTSL        ((uint32_t)0xFFFFFFFFU)  /*!< Receive Packet Timestamp Low  */
 
-/** 
+/**
   * @brief  Bit definition of Rx context descriptor register 1
   */
 #define ETH_DMARXCDESC_RTSH        ((uint32_t)0xFFFFFFFFU)  /*!< Receive Packet Timestamp High  */
 
-/** 
+/**
   * @brief  Bit definition of Rx context descriptor register 3
   */
 #define ETH_DMARXCDESC_OWN        ((uint32_t)0x80000000U)  /*!< Own Bit  */
@@ -875,7 +1002,7 @@ typedef struct{
 
 /** @defgroup ETH_Frame_settings ETH frame settings
   * @{
-  */ 
+  */
 #define ETH_MAX_PACKET_SIZE      ((uint32_t)1528U)    /*!< ETH_HEADER + 2*VLAN_TAG + MAX_ETH_PAYLOAD + ETH_CRC */
 #define ETH_HEADER               ((uint32_t)14U)    /*!< 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
 #define ETH_CRC                  ((uint32_t)4U)    /*!< Ethernet CRC */
@@ -889,7 +1016,7 @@ typedef struct{
 
 /** @defgroup ETH_Error_Code ETH Error Code
   * @{
-  */ 
+  */
 #define HAL_ETH_ERROR_NONE         ((uint32_t)0x00000000U)   /*!< No error            */
 #define HAL_ETH_ERROR_PARAM        ((uint32_t)0x00000001U)   /*!< Busy error          */
 #define HAL_ETH_ERROR_BUSY         ((uint32_t)0x00000002U)   /*!< Parameter error     */
@@ -941,9 +1068,9 @@ typedef struct{
   * @{
   */
 #define ETH_CHECKSUM_DISABLE                         ETH_DMATXNDESCRF_CIC_DISABLE
-#define ETH_CHECKSUM_IPHDR_INSERT                    ETH_DMATXNDESCRF_CIC_IPHDR_INSERT     
-#define ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT            ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT              
-#define ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT_PHDR_CALC  ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT_PHDR_CALC         
+#define ETH_CHECKSUM_IPHDR_INSERT                    ETH_DMATXNDESCRF_CIC_IPHDR_INSERT
+#define ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT            ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT
+#define ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT_PHDR_CALC  ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT_PHDR_CALC
 /**
   * @}
   */
@@ -953,7 +1080,7 @@ typedef struct{
   */
 #define ETH_VLAN_DISABLE  ETH_DMATXNDESCRF_VTIR_DISABLE
 #define ETH_VLAN_REMOVE   ETH_DMATXNDESCRF_VTIR_REMOVE
-#define ETH_VLAN_INSERT   ETH_DMATXNDESCRF_VTIR_INSERT 
+#define ETH_VLAN_INSERT   ETH_DMATXNDESCRF_VTIR_INSERT
 #define ETH_VLAN_REPLACE  ETH_DMATXNDESCRF_VTIR_REPLACE
 /**
   * @}
@@ -964,7 +1091,7 @@ typedef struct{
   */
 #define ETH_INNER_VLAN_DISABLE  ETH_DMATXCDESC_IVTIR_DISABLE
 #define ETH_INNER_VLAN_REMOVE   ETH_DMATXCDESC_IVTIR_REMOVE
-#define ETH_INNER_VLAN_INSERT   ETH_DMATXCDESC_IVTIR_INSERT 
+#define ETH_INNER_VLAN_INSERT   ETH_DMATXCDESC_IVTIR_INSERT
 #define ETH_INNER_VLAN_REPLACE  ETH_DMATXCDESC_IVTIR_REPLACE
 /**
   * @}
@@ -1010,7 +1137,6 @@ typedef struct{
 /**
   * @}
   */
-
 /** @defgroup ETH_Rx_L3_Filter_Status ETH Rx L3 Filter Status
   * @{
   */
@@ -1044,7 +1170,7 @@ typedef struct{
 
 /** @defgroup ETH_DMA_Arbitration ETH DMA Arbitration
   * @{
-  */ 
+  */
 #define ETH_DMAARBITRATION_RX        ETH_DMAMR_DA
 #define ETH_DMAARBITRATION_RX1_TX1   ((uint32_t)0x00000000U)
 #define ETH_DMAARBITRATION_RX2_TX1   ETH_DMAMR_PR_2_1
@@ -1067,74 +1193,74 @@ typedef struct{
   * @}
   */
 
- /** @defgroup ETH_Burst_Mode ETH Burst Mode  
+/** @defgroup ETH_Burst_Mode ETH Burst Mode
   * @{
-  */ 
+  */
 #define ETH_BURSTLENGTH_FIXED           ETH_DMASBMR_FB
 #define ETH_BURSTLENGTH_MIXED           ETH_DMASBMR_MB
 #define ETH_BURSTLENGTH_UNSPECIFIED     ((uint32_t)0x00000000U)
 /**
   * @}
   */
-	
+
 /** @defgroup ETH_Tx_DMA_Burst_Length ETH Tx DMA Burst Length
   * @{
-  */ 
-#define ETH_TXDMABURSTLENGTH_1BEAT          ETH_DMACTCR_TPBL_1PBL   
-#define ETH_TXDMABURSTLENGTH_2BEAT          ETH_DMACTCR_TPBL_2PBL   
-#define ETH_TXDMABURSTLENGTH_4BEAT          ETH_DMACTCR_TPBL_4PBL   
-#define ETH_TXDMABURSTLENGTH_8BEAT          ETH_DMACTCR_TPBL_8PBL   
-#define ETH_TXDMABURSTLENGTH_16BEAT         ETH_DMACTCR_TPBL_16PBL  
-#define ETH_TXDMABURSTLENGTH_32BEAT         ETH_DMACTCR_TPBL_32PBL                  
+  */
+#define ETH_TXDMABURSTLENGTH_1BEAT          ETH_DMACTCR_TPBL_1PBL
+#define ETH_TXDMABURSTLENGTH_2BEAT          ETH_DMACTCR_TPBL_2PBL
+#define ETH_TXDMABURSTLENGTH_4BEAT          ETH_DMACTCR_TPBL_4PBL
+#define ETH_TXDMABURSTLENGTH_8BEAT          ETH_DMACTCR_TPBL_8PBL
+#define ETH_TXDMABURSTLENGTH_16BEAT         ETH_DMACTCR_TPBL_16PBL
+#define ETH_TXDMABURSTLENGTH_32BEAT         ETH_DMACTCR_TPBL_32PBL
 /**
   * @}
   */
 
 /** @defgroup ETH_Rx_DMA_Burst_Length ETH Rx DMA Burst Length
   * @{
-  */ 
-#define ETH_RXDMABURSTLENGTH_1BEAT          ETH_DMACRCR_RPBL_1PBL   
-#define ETH_RXDMABURSTLENGTH_2BEAT          ETH_DMACRCR_RPBL_2PBL   
-#define ETH_RXDMABURSTLENGTH_4BEAT          ETH_DMACRCR_RPBL_4PBL   
-#define ETH_RXDMABURSTLENGTH_8BEAT          ETH_DMACRCR_RPBL_8PBL   
-#define ETH_RXDMABURSTLENGTH_16BEAT         ETH_DMACRCR_RPBL_16PBL  
-#define ETH_RXDMABURSTLENGTH_32BEAT         ETH_DMACRCR_RPBL_32PBL                  
+  */
+#define ETH_RXDMABURSTLENGTH_1BEAT          ETH_DMACRCR_RPBL_1PBL
+#define ETH_RXDMABURSTLENGTH_2BEAT          ETH_DMACRCR_RPBL_2PBL
+#define ETH_RXDMABURSTLENGTH_4BEAT          ETH_DMACRCR_RPBL_4PBL
+#define ETH_RXDMABURSTLENGTH_8BEAT          ETH_DMACRCR_RPBL_8PBL
+#define ETH_RXDMABURSTLENGTH_16BEAT         ETH_DMACRCR_RPBL_16PBL
+#define ETH_RXDMABURSTLENGTH_32BEAT         ETH_DMACRCR_RPBL_32PBL
 /**
   * @}
-  */	
-	
+  */
+
 /** @defgroup ETH_DMA_Interrupts ETH DMA Interrupts
   * @{
-  */	
-#define ETH_DMA_NORMAL_IT                 ETH_DMACIER_NIE 
-#define ETH_DMA_ABNORMAL_IT               ETH_DMACIER_AIE 
+  */
+#define ETH_DMA_NORMAL_IT                 ETH_DMACIER_NIE
+#define ETH_DMA_ABNORMAL_IT               ETH_DMACIER_AIE
 #define ETH_DMA_CONTEXT_DESC_ERROR_IT     ETH_DMACIER_CDEE
 #define ETH_DMA_FATAL_BUS_ERROR_IT        ETH_DMACIER_FBEE
 #define ETH_DMA_EARLY_RX_IT               ETH_DMACIER_ERIE
 #define ETH_DMA_EARLY_TX_IT               ETH_DMACIER_ETIE
 #define ETH_DMA_RX_WATCHDOG_TIMEOUT_IT    ETH_DMACIER_RWTE
-#define ETH_DMA_RX_PROCESS_STOPPED_IT     ETH_DMACIER_RSE 
+#define ETH_DMA_RX_PROCESS_STOPPED_IT     ETH_DMACIER_RSE
 #define ETH_DMA_RX_BUFFER_UNAVAILABLE_IT  ETH_DMACIER_RBUE
-#define ETH_DMA_RX_IT                     ETH_DMACIER_RIE 
+#define ETH_DMA_RX_IT                     ETH_DMACIER_RIE
 #define ETH_DMA_TX_BUFFER_UNAVAILABLE_IT  ETH_DMACIER_TBUE
 #define ETH_DMA_TX_PROCESS_STOPPED_IT     ETH_DMACIER_TXSE
-#define ETH_DMA_TX_IT                     ETH_DMACIER_TIE 
+#define ETH_DMA_TX_IT                     ETH_DMACIER_TIE
 /**
   * @}
   */
 
 /** @defgroup ETH_DMA_Status_Flags ETH DMA Status Flags
   * @{
-  */	
+  */
 #define ETH_DMA_RX_NO_ERROR_FLAG                 ((uint32_t)0x00000000U)
-#define ETH_DMA_RX_DESC_READ_ERROR_FLAG          (ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_1 | ETH_DMACSR_REB_BIT_0)     
-#define ETH_DMA_RX_DESC_WRITE_ERROR_FLAG         (ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_1)       
-#define ETH_DMA_RX_BUFFER_READ_ERROR_FLAG        (ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_0)      
+#define ETH_DMA_RX_DESC_READ_ERROR_FLAG          (ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_1 | ETH_DMACSR_REB_BIT_0)
+#define ETH_DMA_RX_DESC_WRITE_ERROR_FLAG         (ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_1)
+#define ETH_DMA_RX_BUFFER_READ_ERROR_FLAG        (ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_0)
 #define ETH_DMA_RX_BUFFER_WRITE_ERROR_FLAG        ETH_DMACSR_REB_BIT_2
 #define ETH_DMA_TX_NO_ERROR_FLAG                 ((uint32_t)0x00000000U)
-#define ETH_DMA_TX_DESC_READ_ERROR_FLAG          (ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_1 | ETH_DMACSR_TEB_BIT_0)     
-#define ETH_DMA_TX_DESC_WRITE_ERROR_FLAG         (ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_1)      
-#define ETH_DMA_TX_BUFFER_READ_ERROR_FLAG        (ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_0)     
+#define ETH_DMA_TX_DESC_READ_ERROR_FLAG          (ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_1 | ETH_DMACSR_TEB_BIT_0)
+#define ETH_DMA_TX_DESC_WRITE_ERROR_FLAG         (ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_1)
+#define ETH_DMA_TX_BUFFER_READ_ERROR_FLAG        (ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_0)
 #define ETH_DMA_TX_BUFFER_WRITE_ERROR_FLAG        ETH_DMACSR_TEB_BIT_2
 #define ETH_DMA_CONTEXT_DESC_ERROR_FLAG           ETH_DMACSR_CDE
 #define ETH_DMA_FATAL_BUS_ERROR_FLAG              ETH_DMACSR_FBE
@@ -1145,52 +1271,52 @@ typedef struct{
 #define ETH_DMA_TX_PROCESS_STOPPED_FLAG           ETH_DMACSR_TPS
 /**
   * @}
-  */	
-	
-/** @defgroup ETH_Transmit_Mode ETH Transmit Mode 
+  */
+
+/** @defgroup ETH_Transmit_Mode ETH Transmit Mode
   * @{
-  */ 
+  */
 #define ETH_TRANSMITSTOREFORWARD       ETH_MTLTQOMR_TSF
-#define ETH_TRANSMITTHRESHOLD_32       ETH_MTLTQOMR_TTC_32BITS  
-#define ETH_TRANSMITTHRESHOLD_64       ETH_MTLTQOMR_TTC_64BITS  
-#define ETH_TRANSMITTHRESHOLD_96       ETH_MTLTQOMR_TTC_96BITS  
-#define ETH_TRANSMITTHRESHOLD_128      ETH_MTLTQOMR_TTC_128BITS 
-#define ETH_TRANSMITTHRESHOLD_192      ETH_MTLTQOMR_TTC_192BITS 
-#define ETH_TRANSMITTHRESHOLD_256      ETH_MTLTQOMR_TTC_256BITS 
-#define ETH_TRANSMITTHRESHOLD_384      ETH_MTLTQOMR_TTC_384BITS 
-#define ETH_TRANSMITTHRESHOLD_512      ETH_MTLTQOMR_TTC_512BITS 
+#define ETH_TRANSMITTHRESHOLD_32       ETH_MTLTQOMR_TTC_32BITS
+#define ETH_TRANSMITTHRESHOLD_64       ETH_MTLTQOMR_TTC_64BITS
+#define ETH_TRANSMITTHRESHOLD_96       ETH_MTLTQOMR_TTC_96BITS
+#define ETH_TRANSMITTHRESHOLD_128      ETH_MTLTQOMR_TTC_128BITS
+#define ETH_TRANSMITTHRESHOLD_192      ETH_MTLTQOMR_TTC_192BITS
+#define ETH_TRANSMITTHRESHOLD_256      ETH_MTLTQOMR_TTC_256BITS
+#define ETH_TRANSMITTHRESHOLD_384      ETH_MTLTQOMR_TTC_384BITS
+#define ETH_TRANSMITTHRESHOLD_512      ETH_MTLTQOMR_TTC_512BITS
 /**
   * @}
   */
 
-/** @defgroup ETH_Receive_Mode ETH Receive Mode 
+/** @defgroup ETH_Receive_Mode ETH Receive Mode
   * @{
-  */ 
+  */
 #define ETH_RECEIVESTOREFORWARD        ETH_MTLRQOMR_RSF
-#define ETH_RECEIVETHRESHOLD8_64       ETH_MTLRQOMR_RTC_64BITS  
-#define ETH_RECEIVETHRESHOLD8_32       ETH_MTLRQOMR_RTC_32BITS  
-#define ETH_RECEIVETHRESHOLD8_96       ETH_MTLRQOMR_RTC_96BITS  
-#define ETH_RECEIVETHRESHOLD8_128      ETH_MTLRQOMR_RTC_128BITS 
+#define ETH_RECEIVETHRESHOLD8_64       ETH_MTLRQOMR_RTC_64BITS
+#define ETH_RECEIVETHRESHOLD8_32       ETH_MTLRQOMR_RTC_32BITS
+#define ETH_RECEIVETHRESHOLD8_96       ETH_MTLRQOMR_RTC_96BITS
+#define ETH_RECEIVETHRESHOLD8_128      ETH_MTLRQOMR_RTC_128BITS
 /**
   * @}
   */
-	
+
 /** @defgroup ETH_Pause_Low_Threshold  ETH Pause Low Threshold
   * @{
-  */ 
-#define ETH_PAUSELOWTHRESHOLD_MINUS_4        ETH_MACTFCR_PLT_MINUS4  
-#define ETH_PAUSELOWTHRESHOLD_MINUS_28       ETH_MACTFCR_PLT_MINUS28 
-#define ETH_PAUSELOWTHRESHOLD_MINUS_36       ETH_MACTFCR_PLT_MINUS36  
-#define ETH_PAUSELOWTHRESHOLD_MINUS_144      ETH_MACTFCR_PLT_MINUS144 
-#define ETH_PAUSELOWTHRESHOLD_MINUS_256      ETH_MACTFCR_PLT_MINUS256 
-#define ETH_PAUSELOWTHRESHOLD_MINUS_512      ETH_MACTFCR_PLT_MINUS512 
+  */
+#define ETH_PAUSELOWTHRESHOLD_MINUS_4        ETH_MACTFCR_PLT_MINUS4
+#define ETH_PAUSELOWTHRESHOLD_MINUS_28       ETH_MACTFCR_PLT_MINUS28
+#define ETH_PAUSELOWTHRESHOLD_MINUS_36       ETH_MACTFCR_PLT_MINUS36
+#define ETH_PAUSELOWTHRESHOLD_MINUS_144      ETH_MACTFCR_PLT_MINUS144
+#define ETH_PAUSELOWTHRESHOLD_MINUS_256      ETH_MACTFCR_PLT_MINUS256
+#define ETH_PAUSELOWTHRESHOLD_MINUS_512      ETH_MACTFCR_PLT_MINUS512
 /**
   * @}
   */
-	
+
 /** @defgroup ETH_Watchdog_Timeout ETH Watchdog Timeout
   * @{
-  */ 
+  */
 #define ETH_WATCHDOGTIMEOUT_2KB      ETH_MACWTR_WTO_2KB
 #define ETH_WATCHDOGTIMEOUT_3KB      ETH_MACWTR_WTO_3KB
 #define ETH_WATCHDOGTIMEOUT_4KB      ETH_MACWTR_WTO_4KB
@@ -1208,55 +1334,55 @@ typedef struct{
 #define ETH_WATCHDOGTIMEOUT_16KB     ETH_MACWTR_WTO_16KB
 /**
   * @}
-  */  
+  */
 
 /** @defgroup ETH_Inter_Packet_Gap ETH Inter Packet Gap
   * @{
-  */ 
-#define ETH_INTERPACKETGAP_96BIT   ETH_MACCR_IPG_96BIT 
-#define ETH_INTERPACKETGAP_88BIT   ETH_MACCR_IPG_88BIT 
-#define ETH_INTERPACKETGAP_80BIT   ETH_MACCR_IPG_80BIT  
-#define ETH_INTERPACKETGAP_72BIT   ETH_MACCR_IPG_72BIT 
-#define ETH_INTERPACKETGAP_64BIT   ETH_MACCR_IPG_64BIT  
-#define ETH_INTERPACKETGAP_56BIT   ETH_MACCR_IPG_56BIT  
-#define ETH_INTERPACKETGAP_48BIT   ETH_MACCR_IPG_48BIT 
-#define ETH_INTERPACKETGAP_40BIT   ETH_MACCR_IPG_40BIT 
+  */
+#define ETH_INTERPACKETGAP_96BIT   ETH_MACCR_IPG_96BIT
+#define ETH_INTERPACKETGAP_88BIT   ETH_MACCR_IPG_88BIT
+#define ETH_INTERPACKETGAP_80BIT   ETH_MACCR_IPG_80BIT
+#define ETH_INTERPACKETGAP_72BIT   ETH_MACCR_IPG_72BIT
+#define ETH_INTERPACKETGAP_64BIT   ETH_MACCR_IPG_64BIT
+#define ETH_INTERPACKETGAP_56BIT   ETH_MACCR_IPG_56BIT
+#define ETH_INTERPACKETGAP_48BIT   ETH_MACCR_IPG_48BIT
+#define ETH_INTERPACKETGAP_40BIT   ETH_MACCR_IPG_40BIT
 /**
   * @}
   */
 
 /** @defgroup ETH_Speed  ETH Speed
   * @{
-  */ 
+  */
 #define ETH_SPEED_10M        ((uint32_t)0x00000000U)
 #define ETH_SPEED_100M       ETH_MACCR_FES
 /**
   * @}
   */
 
-/** @defgroup ETH_Duplex_Mode ETH Duplex Mode 
+/** @defgroup ETH_Duplex_Mode ETH Duplex Mode
   * @{
-  */ 
+  */
 #define ETH_FULLDUPLEX_MODE       ETH_MACCR_DM
 #define ETH_HALFDUPLEX_MODE       ((uint32_t)0x00000000U)
 /**
   * @}
   */
-	
+
 /** @defgroup ETH_Back_Off_Limit ETH Back Off Limit
   * @{
-  */ 
+  */
 #define ETH_BACKOFFLIMIT_10  ETH_MACCR_BL_10
-#define ETH_BACKOFFLIMIT_8   ETH_MACCR_BL_8 
-#define ETH_BACKOFFLIMIT_4   ETH_MACCR_BL_4 
-#define ETH_BACKOFFLIMIT_1   ETH_MACCR_BL_1 
+#define ETH_BACKOFFLIMIT_8   ETH_MACCR_BL_8
+#define ETH_BACKOFFLIMIT_4   ETH_MACCR_BL_4
+#define ETH_BACKOFFLIMIT_1   ETH_MACCR_BL_1
 /**
   * @}
   */
 
 /** @defgroup ETH_Preamble_Length ETH Preamble Length
   * @{
-  */ 
+  */
 #define ETH_PREAMBLELENGTH_7      ETH_MACCR_PRELEN_7
 #define ETH_PREAMBLELENGTH_5      ETH_MACCR_PRELEN_5
 #define ETH_PREAMBLELENGTH_3      ETH_MACCR_PRELEN_3
@@ -1266,7 +1392,7 @@ typedef struct{
 
 /** @defgroup ETH_Source_Addr_Control ETH Source Addr Control
   * @{
-  */ 
+  */
 #define ETH_SOURCEADDRESS_DISABLE           ((uint32_t)0x00000000U)
 #define ETH_SOURCEADDRESS_INSERT_ADDR0      ETH_MACCR_SARC_INSADDR0
 #define ETH_SOURCEADDRESS_INSERT_ADDR1      ETH_MACCR_SARC_INSADDR1
@@ -1275,10 +1401,10 @@ typedef struct{
 /**
   * @}
   */
-  
+
 /** @defgroup ETH_Control_Packets_Filter ETH Control Packets Filter
   * @{
-  */ 
+  */
 #define ETH_CTRLPACKETS_BLOCK_ALL                      ETH_MACPFR_PCF_BLOCKALL
 #define ETH_CTRLPACKETS_FORWARD_ALL_EXCEPT_PA          ETH_MACPFR_PCF_FORWARDALLEXCEPTPA
 #define ETH_CTRLPACKETS_FORWARD_ALL                    ETH_MACPFR_PCF_FORWARDALL
@@ -1286,10 +1412,10 @@ typedef struct{
 /**
   * @}
   */
-	
+
 /** @defgroup ETH_VLAN_Tag_Comparison ETH VLAN Tag Comparison
   * @{
-  */ 
+  */
 #define ETH_VLANTAGCOMPARISON_16BIT          ((uint32_t)0x00000000U)
 #define ETH_VLANTAGCOMPARISON_12BIT          ETH_MACVTR_ETV
 /**
@@ -1298,20 +1424,20 @@ typedef struct{
 
 /** @defgroup ETH_MAC_addresses ETH MAC addresses
   * @{
-  */ 
+  */
 #define ETH_MAC_ADDRESS0     ((uint32_t)0x00000000U)
 #define ETH_MAC_ADDRESS1     ((uint32_t)0x00000008U)
 #define ETH_MAC_ADDRESS2     ((uint32_t)0x00000010U)
 #define ETH_MAC_ADDRESS3     ((uint32_t)0x00000018U)
 /**
   * @}
-  */    
- 
+  */
+
 /** @defgroup ETH_MAC_Interrupts ETH MAC Interrupts
   * @{
-  */	
-#define ETH_MAC_RX_STATUS_IT     ETH_MACIER_RXSTSIE 
-#define ETH_MAC_TX_STATUS_IT     ETH_MACIER_TXSTSIE 
+  */
+#define ETH_MAC_RX_STATUS_IT     ETH_MACIER_RXSTSIE
+#define ETH_MAC_TX_STATUS_IT     ETH_MACIER_TXSTSIE
 #define ETH_MAC_TIMESTAMP_IT     ETH_MACIER_TSIE
 #define ETH_MAC_LPI_IT           ETH_MACIER_LPIIE
 #define ETH_MAC_PMT_IT           ETH_MACIER_PMTIE
@@ -1322,9 +1448,9 @@ typedef struct{
 
 /** @defgroup ETH_MAC_Wake_Up_Event ETH MAC Wake Up Event
   * @{
-  */	
-#define ETH_WAKEUP_PACKET_RECIEVED    ETH_MACPCSR_RWKPRCVD 
-#define ETH_MAGIC_PACKET_RECIEVED     ETH_MACPCSR_MGKPRCVD 
+  */
+#define ETH_WAKEUP_PACKET_RECIEVED    ETH_MACPCSR_RWKPRCVD
+#define ETH_MAGIC_PACKET_RECIEVED     ETH_MACPCSR_MGKPRCVD
 /**
   * @}
   */
@@ -1334,11 +1460,11 @@ typedef struct{
   */
 #define ETH_RECEIVE_WATCHDOG_TIMEOUT        ETH_MACRXTXSR_RWT
 #define ETH_EXECESSIVE_COLLISIONS           ETH_MACRXTXSR_EXCOL
-#define ETH_LATE_COLLISIONS                 ETH_MACRXTXSR_LCOL 
+#define ETH_LATE_COLLISIONS                 ETH_MACRXTXSR_LCOL
 #define ETH_EXECESSIVE_DEFERRAL             ETH_MACRXTXSR_EXDEF
 #define ETH_LOSS_OF_CARRIER                 ETH_MACRXTXSR_LCARR
 #define ETH_NO_CARRIER                      ETH_MACRXTXSR_NCARR
-#define ETH_TRANSMIT_JABBR_TIMEOUT          ETH_MACRXTXSR_TJT  	
+#define ETH_TRANSMIT_JABBR_TIMEOUT          ETH_MACRXTXSR_TJT
 /**
   * @}
   */
@@ -1349,9 +1475,17 @@ typedef struct{
 #define HAL_ETH_STATE_RESET       ((uint32_t)0x00000000U)    /*!< Peripheral not yet Initialized or disabled */
 #define HAL_ETH_STATE_READY       ((uint32_t)0x00000010U)    /*!< Peripheral Communication started           */
 #define HAL_ETH_STATE_BUSY        ((uint32_t)0x00000023U)    /*!< an internal process is ongoing             */
-#define HAL_ETH_STATE_BUSY_TX     ((uint32_t)0x00000021U)    /*!< Transmission process is ongoing            */
-#define HAL_ETH_STATE_BUSY_RX     ((uint32_t)0x00000022U)    /*!< Reception process is ongoing               */
+#define HAL_ETH_STATE_STARTED     ((uint32_t)0x00000023U)    /*!< an internal process is started             */
 #define HAL_ETH_STATE_ERROR       ((uint32_t)0x000000E0U)    /*!< Error State                                */
+/**
+  * @}
+  */
+
+/** @defgroup ETH_PTP_Config_Status ETH PTP Config Status
+  * @{
+  */
+#define HAL_ETH_PTP_NOT_CONFIGURATED       ((uint32_t)0x00000000U)    /*!< ETH PTP Configuration not done */
+#define HAL_ETH_PTP_CONFIGURATED           ((uint32_t)0x00000001U)    /*!< ETH PTP Configuration done     */
 /**
   * @}
   */
@@ -1370,26 +1504,24 @@ typedef struct{
   */
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
 #define __HAL_ETH_RESET_HANDLE_STATE(__HANDLE__)  do{                                                   \
-                                                       (__HANDLE__)->gState = HAL_ETH_STATE_RESET;      \
-                                                       (__HANDLE__)->RxState = HAL_ETH_STATE_RESET;     \
-                                                       (__HANDLE__)->MspInitCallback = NULL;             \
-                                                       (__HANDLE__)->MspDeInitCallback = NULL;           \
-                                                     } while(0)
+                                                      (__HANDLE__)->gState = HAL_ETH_STATE_RESET;      \
+                                                      (__HANDLE__)->MspInitCallback = NULL;             \
+                                                      (__HANDLE__)->MspDeInitCallback = NULL;           \
+                                                    } while(0)
 #else
 #define __HAL_ETH_RESET_HANDLE_STATE(__HANDLE__)  do{                                                   \
-                                                       (__HANDLE__)->gState = HAL_ETH_STATE_RESET;      \
-                                                       (__HANDLE__)->RxState = HAL_ETH_STATE_RESET;     \
-                                                     } while(0)
+                                                      (__HANDLE__)->gState = HAL_ETH_STATE_RESET;      \
+                                                    } while(0)
 #endif /*USE_HAL_ETH_REGISTER_CALLBACKS */
 
-/** 
+/**
   * @brief  Enables the specified ETHERNET DMA interrupts.
   * @param  __HANDLE__   : ETH Handle
   * @param  __INTERRUPT__: specifies the ETHERNET DMA interrupt sources to be
   *   enabled @ref ETH_DMA_Interrupts
   * @retval None
   */
-#define __HAL_ETH_DMA_ENABLE_IT(__HANDLE__, __INTERRUPT__)                 ((__HANDLE__)->Instance->DMACIER |= (__INTERRUPT__))
+#define __HAL_ETH_DMA_ENABLE_IT(__HANDLE__, __INTERRUPT__) ((__HANDLE__)->Instance->DMACIER |= (__INTERRUPT__))
 
 /**
   * @brief  Disables the specified ETHERNET DMA interrupts.
@@ -1398,7 +1530,7 @@ typedef struct{
   *   disabled. @ref ETH_DMA_Interrupts
   * @retval None
   */
-#define __HAL_ETH_DMA_DISABLE_IT(__HANDLE__, __INTERRUPT__)                ((__HANDLE__)->Instance->DMACIER &= ~(__INTERRUPT__))
+#define __HAL_ETH_DMA_DISABLE_IT(__HANDLE__, __INTERRUPT__) ((__HANDLE__)->Instance->DMACIER &= ~(__INTERRUPT__))
 
 /**
   * @brief  Gets the ETHERNET DMA IT source enabled or disabled.
@@ -1406,7 +1538,8 @@ typedef struct{
   * @param  __INTERRUPT__: specifies the interrupt source to get . @ref ETH_DMA_Interrupts
   * @retval The ETH DMA IT Source enabled or disabled
   */
-#define __HAL_ETH_DMA_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)      (((__HANDLE__)->Instance->DMACIER &  (__INTERRUPT__)) == (__INTERRUPT__))
+#define __HAL_ETH_DMA_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) \
+  (((__HANDLE__)->Instance->DMACIER &  (__INTERRUPT__)) == (__INTERRUPT__))
 
 /**
   * @brief  Gets the ETHERNET DMA IT pending bit.
@@ -1414,57 +1547,59 @@ typedef struct{
   * @param  __INTERRUPT__: specifies the interrupt source to get . @ref ETH_DMA_Interrupts
   * @retval The state of ETH DMA IT (SET or RESET)
   */
-#define __HAL_ETH_DMA_GET_IT(__HANDLE__, __INTERRUPT__)      (((__HANDLE__)->Instance->DMACSR &  (__INTERRUPT__)) == (__INTERRUPT__))
-    
+#define __HAL_ETH_DMA_GET_IT(__HANDLE__, __INTERRUPT__) \
+  (((__HANDLE__)->Instance->DMACSR &  (__INTERRUPT__)) == (__INTERRUPT__))
+
 /**
   * @brief  Clears the ETHERNET DMA IT pending bit.
   * @param  __HANDLE__   : ETH Handle
   * @param  __INTERRUPT__: specifies the interrupt pending bit to clear. @ref ETH_DMA_Interrupts
   * @retval None
   */
-#define __HAL_ETH_DMA_CLEAR_IT(__HANDLE__, __INTERRUPT__)      ((__HANDLE__)->Instance->DMACSR = (__INTERRUPT__))
+#define __HAL_ETH_DMA_CLEAR_IT(__HANDLE__, __INTERRUPT__) ((__HANDLE__)->Instance->DMACSR = (__INTERRUPT__))
 
 /**
   * @brief  Checks whether the specified ETHERNET DMA flag is set or not.
-* @param  __HANDLE__: ETH Handle
+  * @param  __HANDLE__: ETH Handle
   * @param  __FLAG__: specifies the flag to check. @ref ETH_DMA_Status_Flags
   * @retval The state of ETH DMA FLAG (SET or RESET).
   */
-#define __HAL_ETH_DMA_GET_FLAG(__HANDLE__, __FLAG__)                   (((__HANDLE__)->Instance->DMACSR &( __FLAG__)) == ( __FLAG__))  
+#define __HAL_ETH_DMA_GET_FLAG(__HANDLE__, __FLAG__) (((__HANDLE__)->Instance->DMACSR &( __FLAG__)) == ( __FLAG__))
 
 /**
   * @brief  Clears the specified ETHERNET DMA flag.
-* @param  __HANDLE__: ETH Handle
+  * @param  __HANDLE__: ETH Handle
   * @param  __FLAG__: specifies the flag to check. @ref ETH_DMA_Status_Flags
   * @retval The state of ETH DMA FLAG (SET or RESET).
   */
-#define __HAL_ETH_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__)                   ((__HANDLE__)->Instance->DMACSR = ( __FLAG__))
-    
-/** 
+#define __HAL_ETH_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->DMACSR = ( __FLAG__))
+
+/**
   * @brief  Enables the specified ETHERNET MAC interrupts.
   * @param  __HANDLE__   : ETH Handle
   * @param  __INTERRUPT__: specifies the ETHERNET MAC interrupt sources to be
   *   enabled @ref ETH_MAC_Interrupts
   * @retval None
   */
-#define __HAL_ETH_MAC_ENABLE_IT(__HANDLE__, __INTERRUPT__)                 ((__HANDLE__)->Instance->MACIER |= (__INTERRUPT__))
-    
-/** 
+#define __HAL_ETH_MAC_ENABLE_IT(__HANDLE__, __INTERRUPT__) ((__HANDLE__)->Instance->MACIER |= (__INTERRUPT__))
+
+/**
   * @brief  Disables the specified ETHERNET MAC interrupts.
   * @param  __HANDLE__   : ETH Handle
   * @param  __INTERRUPT__: specifies the ETHERNET MAC interrupt sources to be
   *   enabled @ref ETH_MAC_Interrupts
   * @retval None
   */
-#define __HAL_ETH_MAC_DISABLE_IT(__HANDLE__, __INTERRUPT__)                 ((__HANDLE__)->Instance->MACIER &= ~(__INTERRUPT__))
-  
+#define __HAL_ETH_MAC_DISABLE_IT(__HANDLE__, __INTERRUPT__) ((__HANDLE__)->Instance->MACIER &= ~(__INTERRUPT__))
+
 /**
   * @brief  Checks whether the specified ETHERNET MAC flag is set or not.
   * @param  __HANDLE__: ETH Handle
   * @param  __INTERRUPT__: specifies the flag to check. @ref ETH_MAC_Interrupts
   * @retval The state of ETH MAC IT (SET or RESET).
   */
-#define __HAL_ETH_MAC_GET_IT(__HANDLE__, __INTERRUPT__)                   (((__HANDLE__)->Instance->MACISR &( __INTERRUPT__)) == ( __INTERRUPT__)) 
+#define __HAL_ETH_MAC_GET_IT(__HANDLE__, __INTERRUPT__) \
+  (((__HANDLE__)->Instance->MACISR &( __INTERRUPT__)) == ( __INTERRUPT__))
 
 /*!< External interrupt line 86 Connected to the ETH wakeup EXTI Line */
 #define ETH_WAKEUP_EXTI_LINE  ((uint32_t)0x00400000U)  /* !<  86 - 64 = 22 */
@@ -1472,7 +1607,7 @@ typedef struct{
 /**
   * @brief Enable the ETH WAKEUP Exti Line.
   * @param  __EXTI_LINE__: specifies the ETH WAKEUP Exti sources to be enabled.
-  *   @arg ETH_WAKEUP_EXTI_LINE     
+  *   @arg ETH_WAKEUP_EXTI_LINE
   * @retval None.
   */
 #define __HAL_ETH_WAKEUP_EXTI_ENABLE_IT(__EXTI_LINE__)   (EXTI_D1->IMR3 |= (__EXTI_LINE__))
@@ -1480,7 +1615,7 @@ typedef struct{
 /**
   * @brief checks whether the specified ETH WAKEUP Exti interrupt flag is set or not.
   * @param  __EXTI_LINE__: specifies the ETH WAKEUP Exti sources to be cleared.
-  *   @arg ETH_WAKEUP_EXTI_LINE  
+  *   @arg ETH_WAKEUP_EXTI_LINE
   * @retval EXTI ETH WAKEUP Line Status.
   */
 #define __HAL_ETH_WAKEUP_EXTI_GET_FLAG(__EXTI_LINE__)  (EXTI_D1->PR3 & (__EXTI_LINE__))
@@ -1488,7 +1623,7 @@ typedef struct{
 /**
   * @brief Clear the ETH WAKEUP Exti flag.
   * @param  __EXTI_LINE__: specifies the ETH WAKEUP Exti sources to be cleared.
-  *   @arg ETH_WAKEUP_EXTI_LINE  
+  *   @arg ETH_WAKEUP_EXTI_LINE
   * @retval None.
   */
 #define __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG(__EXTI_LINE__) (EXTI_D1->PR3 = (__EXTI_LINE__))
@@ -1497,15 +1632,15 @@ typedef struct{
 /**
   * @brief Enable the ETH WAKEUP Exti Line by Core2.
   * @param  __EXTI_LINE__: specifies the ETH WAKEUP Exti sources to be enabled.
-  *   @arg ETH_WAKEUP_EXTI_LINE     
+  *   @arg ETH_WAKEUP_EXTI_LINE
   * @retval None.
   */
-#define __HAL_ETH_WAKEUP_EXTID2_ENABLE_IT(__EXTI_LINE__)   (EXTI_D2->IMR3 |= (__EXTI_LINE__)) 
+#define __HAL_ETH_WAKEUP_EXTID2_ENABLE_IT(__EXTI_LINE__)   (EXTI_D2->IMR3 |= (__EXTI_LINE__))
 
 /**
   * @brief checks whether the specified ETH WAKEUP Exti interrupt flag is set or not.
   * @param  __EXTI_LINE__: specifies the ETH WAKEUP Exti sources to be cleared.
-  *   @arg ETH_WAKEUP_EXTI_LINE  
+  *   @arg ETH_WAKEUP_EXTI_LINE
   * @retval EXTI ETH WAKEUP Line Status.
   */
 #define __HAL_ETH_WAKEUP_EXTID2_GET_FLAG(__EXTI_LINE__)  (EXTI_D2->PR3 & (__EXTI_LINE__))
@@ -1513,11 +1648,11 @@ typedef struct{
 /**
   * @brief Clear the ETH WAKEUP Exti flag.
   * @param  __EXTI_LINE__: specifies the ETH WAKEUP Exti sources to be cleared.
-  *   @arg ETH_WAKEUP_EXTI_LINE  
+  *   @arg ETH_WAKEUP_EXTI_LINE
   * @retval None.
   */
 #define __HAL_ETH_WAKEUP_EXTID2_CLEAR_FLAG(__EXTI_LINE__) (EXTI_D2->PR3 = (__EXTI_LINE__))
-#endif
+#endif /* DUAL_CORE */
 
 /**
   * @brief  enable rising edge interrupt on selected EXTI line.
@@ -1526,7 +1661,7 @@ typedef struct{
   * @retval None
   */
 #define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE(__EXTI_LINE__) (EXTI->FTSR3 &= ~(__EXTI_LINE__)); \
-                                                                (EXTI->RTSR3 |= (__EXTI_LINE__)) 
+  (EXTI->RTSR3 |= (__EXTI_LINE__))
 
 /**
   * @brief  enable falling edge interrupt on selected EXTI line.
@@ -1535,7 +1670,7 @@ typedef struct{
   * @retval None
   */
 #define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE(__EXTI_LINE__) (EXTI->RTSR3 &= ~(__EXTI_LINE__));\
-                                                                 (EXTI->FTSR3 |= (__EXTI_LINE__))
+  (EXTI->FTSR3 |= (__EXTI_LINE__))
 
 /**
   * @brief  enable falling edge interrupt on selected EXTI line.
@@ -1544,7 +1679,7 @@ typedef struct{
   * @retval None
   */
 #define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_FALLING_EDGE(__EXTI_LINE__) (EXTI->RTSR3 |= (__EXTI_LINE__));\
-                                                                        (EXTI->FTSR3 |= (__EXTI_LINE__))
+  (EXTI->FTSR3 |= (__EXTI_LINE__))
 
 /**
   * @brief  Generates a Software interrupt on selected EXTI line.
@@ -1554,6 +1689,10 @@ typedef struct{
   */
 #define __HAL_ETH_WAKEUP_EXTI_GENERATE_SWIT(__EXTI_LINE__) (EXTI->SWIER3 |= (__EXTI_LINE__))
 
+#define __HAL_ETH_GET_PTP_CONTROL(__HANDLE__, __FLAG__) (((((__HANDLE__)->Instance->MACTSCR) & \
+                                                           (__FLAG__)) == (__FLAG__)) ? SET : RESET)
+
+#define __HAL_ETH_SET_PTP_CONTROL(__HANDLE__, __FLAG__)   ((__HANDLE__)->Instance->MACTSCR |= (__FLAG__))
 /**
   * @}
   */
@@ -1566,20 +1705,20 @@ typedef struct{
 /** @addtogroup ETH_Exported_Functions
   * @{
   */
-  
+
 /** @addtogroup ETH_Exported_Functions_Group1
   * @{
-  */    
+  */
 /* Initialization and de initialization functions  **********************************/
-HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth);                        
-HAL_StatusTypeDef HAL_ETH_DeInit(ETH_HandleTypeDef *heth);                      
-void              HAL_ETH_MspInit(ETH_HandleTypeDef *heth);                    
-void              HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth);  
-HAL_StatusTypeDef HAL_ETH_DescAssignMemory(ETH_HandleTypeDef *heth, uint32_t Index, uint8_t *pBuffer1,uint8_t *pBuffer2);
+HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_DeInit(ETH_HandleTypeDef *heth);
+void              HAL_ETH_MspInit(ETH_HandleTypeDef *heth);
+void              HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth);
 
 /* Callbacks Register/UnRegister functions  ***********************************/
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
-HAL_StatusTypeDef HAL_ETH_RegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_CallbackIDTypeDef CallbackID, pETH_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_ETH_RegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_CallbackIDTypeDef CallbackID,
+                                           pETH_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_ETH_UnRegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_CallbackIDTypeDef CallbackID);
 #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
 
@@ -1596,26 +1735,50 @@ HAL_StatusTypeDef HAL_ETH_Start_IT(ETH_HandleTypeDef *heth);
 HAL_StatusTypeDef HAL_ETH_Stop(ETH_HandleTypeDef *heth);
 HAL_StatusTypeDef HAL_ETH_Stop_IT(ETH_HandleTypeDef *heth);
 
-uint8_t           HAL_ETH_IsRxDataAvailable(ETH_HandleTypeDef *heth);
-HAL_StatusTypeDef HAL_ETH_GetRxDataBuffer(ETH_HandleTypeDef *heth, ETH_BufferTypeDef *RxBuffer);
-HAL_StatusTypeDef HAL_ETH_GetRxDataLength(ETH_HandleTypeDef *heth, uint32_t *Length);
-HAL_StatusTypeDef HAL_ETH_GetRxDataInfo(ETH_HandleTypeDef *heth, ETH_RxPacketInfo *RxPacketInfo);
-HAL_StatusTypeDef HAL_ETH_BuildRxDescriptors(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_ReadData(ETH_HandleTypeDef *heth, void **pAppBuff);
+HAL_StatusTypeDef HAL_ETH_RegisterRxAllocateCallback(ETH_HandleTypeDef *heth,
+                                                     pETH_rxAllocateCallbackTypeDef rxAllocateCallback);
+HAL_StatusTypeDef HAL_ETH_UnRegisterRxAllocateCallback(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_RegisterRxLinkCallback(ETH_HandleTypeDef *heth, pETH_rxLinkCallbackTypeDef rxLinkCallback);
+HAL_StatusTypeDef HAL_ETH_UnRegisterRxLinkCallback(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_GetRxDataErrorCode(ETH_HandleTypeDef *heth, uint32_t *pErrorCode);
+HAL_StatusTypeDef HAL_ETH_RegisterTxFreeCallback(ETH_HandleTypeDef *heth, pETH_txFreeCallbackTypeDef txFreeCallback);
+HAL_StatusTypeDef HAL_ETH_UnRegisterTxFreeCallback(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_ReleaseTxPacket(ETH_HandleTypeDef *heth);
+
+#ifdef HAL_ETH_USE_PTP
+HAL_StatusTypeDef HAL_ETH_PTP_SetConfig(ETH_HandleTypeDef *heth, ETH_PTP_ConfigTypeDef *ptpconfig);
+HAL_StatusTypeDef HAL_ETH_PTP_GetConfig(ETH_HandleTypeDef *heth, ETH_PTP_ConfigTypeDef *ptpconfig);
+HAL_StatusTypeDef HAL_ETH_PTP_SetTime(ETH_HandleTypeDef *heth, ETH_TimeTypeDef *time);
+HAL_StatusTypeDef HAL_ETH_PTP_GetTime(ETH_HandleTypeDef *heth, ETH_TimeTypeDef *time);
+HAL_StatusTypeDef HAL_ETH_PTP_AddTimeOffset(ETH_HandleTypeDef *heth, ETH_PtpUpdateTypeDef ptpoffsettype,
+                                            ETH_TimeTypeDef *timeoffset);
+HAL_StatusTypeDef HAL_ETH_PTP_InsertTxTimestamp(ETH_HandleTypeDef *heth);
+HAL_StatusTypeDef HAL_ETH_PTP_GetTxTimestamp(ETH_HandleTypeDef *heth, ETH_TimeStampTypeDef *timestamp);
+HAL_StatusTypeDef HAL_ETH_PTP_GetRxTimestamp(ETH_HandleTypeDef *heth, ETH_TimeStampTypeDef *timestamp);
+HAL_StatusTypeDef HAL_ETH_RegisterTxPtpCallback(ETH_HandleTypeDef *heth, pETH_txPtpCallbackTypeDef txPtpCallback);
+HAL_StatusTypeDef HAL_ETH_UnRegisterTxPtpCallback(ETH_HandleTypeDef *heth);
+#endif /* HAL_ETH_USE_PTP */
 
 HAL_StatusTypeDef HAL_ETH_Transmit(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig, uint32_t Timeout);
 HAL_StatusTypeDef HAL_ETH_Transmit_IT(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig);
 
-HAL_StatusTypeDef HAL_ETH_WritePHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint32_t PHYReg, uint32_t RegValue);  
-HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint32_t PHYReg, uint32_t *pRegValue); 
+HAL_StatusTypeDef HAL_ETH_WritePHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint32_t PHYReg,
+                                           uint32_t RegValue);
+HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint32_t PHYReg,
+                                          uint32_t *pRegValue);
 
 void              HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth);
 void              HAL_ETH_TxCpltCallback(ETH_HandleTypeDef *heth);
 void              HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth);
-void              HAL_ETH_DMAErrorCallback(ETH_HandleTypeDef *heth);
-void              HAL_ETH_MACErrorCallback(ETH_HandleTypeDef *heth);
+void              HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth);
 void              HAL_ETH_PMTCallback(ETH_HandleTypeDef *heth);
 void              HAL_ETH_EEECallback(ETH_HandleTypeDef *heth);
 void              HAL_ETH_WakeUpCallback(ETH_HandleTypeDef *heth);
+void              HAL_ETH_RxAllocateCallback(uint8_t **buff);
+void              HAL_ETH_RxLinkCallback(void **pStart, void **pEnd, uint8_t *buff, uint16_t Length);
+void              HAL_ETH_TxFreeCallback(uint32_t *buff);
+void              HAL_ETH_TxPtpCallback(uint32_t *buff, ETH_TimeStampTypeDef *timestamp);
 /**
   * @}
   */
@@ -1632,7 +1795,8 @@ HAL_StatusTypeDef HAL_ETH_SetDMAConfig(ETH_HandleTypeDef *heth, ETH_DMAConfigTyp
 void              HAL_ETH_SetMDIOClockRange(ETH_HandleTypeDef *heth);
 
 /* MAC VLAN Processing APIs    ************************************************/
-void              HAL_ETH_SetRxVLANIdentifier(ETH_HandleTypeDef *heth, uint32_t ComparisonBits, uint32_t VLANIdentifier);
+void              HAL_ETH_SetRxVLANIdentifier(ETH_HandleTypeDef *heth, uint32_t ComparisonBits,
+                                              uint32_t VLANIdentifier);
 
 /* MAC L2 Packet Filtering APIs  **********************************************/
 HAL_StatusTypeDef HAL_ETH_GetMACFilterConfig(ETH_HandleTypeDef *heth, ETH_MACFilterConfigTypeDef *pFilterConfig);
@@ -1660,19 +1824,19 @@ uint32_t             HAL_ETH_GetMACError(ETH_HandleTypeDef *heth);
 uint32_t             HAL_ETH_GetMACWakeUpSource(ETH_HandleTypeDef *heth);
 /**
   * @}
-  */ 
+  */
 
 /**
   * @}
-  */ 
+  */
 
 /**
   * @}
-  */ 
+  */
 
 /**
   * @}
-  */ 
+  */
 
 #endif /* ETH */
 
@@ -1683,5 +1847,3 @@ uint32_t             HAL_ETH_GetMACWakeUpSource(ETH_HandleTypeDef *heth);
 #endif /* STM32H7xx_HAL_ETH_H */
 
 
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Inc/stm32h7xx_hal_eth_ex.h
+++ b/Inc/stm32h7xx_hal_eth_ex.h
@@ -6,23 +6,22 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
-  */ 
+  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef STM32H7xx_HAL_ETH_EX_H
 #define STM32H7xx_HAL_ETH_EX_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 #if defined(ETH)
@@ -42,126 +41,131 @@
 /** @defgroup ETHEx_Exported_Types ETHEx Exported Types
   * @{
   */
-  
-/** 
+
+/**
   * @brief  ETH RX VLAN structure definition
   */
-typedef struct{
+typedef struct
+{
   FunctionalState InnerVLANTagInStatus;      /*!< Enables or disables Inner VLAN Tag in Rx Status  */
-	
-  uint32_t StripInnerVLANTag;                /*!< Sets the Inner VLAN Tag Stripping on Receive 
-                                                  This parameter can be a value of @ref ETHEx_Rx_Inner_VLAN_Tag_Stripping */
-	
+
+  uint32_t StripInnerVLANTag;                /*!< Sets the Inner VLAN Tag Stripping on Receive
+                                                  This parameter can be a value of
+                                                  @ref ETHEx_Rx_Inner_VLAN_Tag_Stripping */
+
   FunctionalState InnerVLANTag;              /*!< Enables or disables Inner VLAN Tag */
 
   FunctionalState DoubleVLANProcessing;      /*!< Enable or Disable double VLAN processing */
-	
+
   FunctionalState VLANTagHashTableMatch;     /*!< Enable or Disable VLAN Tag Hash Table Match */
-	
+
   FunctionalState VLANTagInStatus;           /*!< Enable or Disable VLAN Tag in Rx status */
-	
-  uint32_t StripVLANTag;                     /*!< Set the VLAN Tag Stripping on Receive 
+
+  uint32_t StripVLANTag;                     /*!< Set the VLAN Tag Stripping on Receive
                                                   This parameter can be a value of @ref ETHEx_Rx_VLAN_Tag_Stripping */
-	
+
   uint32_t VLANTypeCheck;                    /*!< Enable or Disable VLAN Type Check
                                                   This parameter can be a value of @ref ETHEx_VLAN_Type_Check */
-																				 
-  FunctionalState VLANTagInverceMatch;       /*!< Enable or disable VLAN Tag Inverse Match */																			 
-}ETH_RxVLANConfigTypeDef;
-/** 
-  * 
+
+  FunctionalState VLANTagInverceMatch;       /*!< Enable or disable VLAN Tag Inverse Match */
+} ETH_RxVLANConfigTypeDef;
+/**
+  *
   */
-  
-/** 
+
+/**
   * @brief  ETH TX VLAN structure definition
   */
-typedef struct{
+typedef struct
+{
   FunctionalState SourceTxDesc;   /*!< Enable or Disable VLAN tag source from DMA tx descriptors */
-  
+
   FunctionalState SVLANType;      /*!< Enable or Disable insertion of SVLAN type */
-	
+
   uint32_t VLANTagControl;        /*!< Sets the VLAN tag control in tx packets
                                       This parameter can be a value of @ref ETHEx_VLAN_Tag_Control */
-}ETH_TxVLANConfigTypeDef;
-/** 
-  * 
+} ETH_TxVLANConfigTypeDef;
+/**
+  *
   */
 
-/** 
+/**
   * @brief  ETH L3 filter structure definition
   */
-typedef struct{
+typedef struct
+{
   uint32_t Protocol;                /*!< Sets the L3 filter protocol to IPv4 or IPv6
                                          This parameter can be a value of @ref ETHEx_L3_Protocol */
-  
+
   uint32_t SrcAddrFilterMatch;      /*!< Sets the L3 filter source address match
                                          This parameter can be a value of @ref ETHEx_L3_Source_Match */
-  
+
   uint32_t DestAddrFilterMatch;     /*!< Sets the L3 filter destination address match
                                          This parameter can be a value of @ref ETHEx_L3_Destination_Match */
-  
+
   uint32_t SrcAddrHigherBitsMatch;  /*!< Sets the L3 filter source address higher bits match
                                          This parameter can be a value from 0 to 31 */
-  
+
   uint32_t DestAddrHigherBitsMatch; /*!< Sets the L3 filter destination address higher bits match
                                          This parameter can be a value from 0 to 31 */
-  
+
   uint32_t Ip4SrcAddr;              /*!< Sets the L3 filter IPv4 source address if IPv4 protocol is used
                                          This parameter can be a value from 0x0 to 0xFFFFFFFF */
-  
+
   uint32_t Ip4DestAddr;             /*!< Sets the L3 filter IPv4 destination  address if IPv4 protocol is used
                                          This parameter can be a value from 0 to 0xFFFFFFFF  */
-  
+
   uint32_t Ip6Addr[4];                 /*!< Sets the L3 filter IPv6 address if IPv6 protocol is used
                                           This parameter must be a table of 4 words (4* 32 bits) */
-}ETH_L3FilterConfigTypeDef;
-/** 
-  * 
+} ETH_L3FilterConfigTypeDef;
+/**
+  *
   */
 
-/** 
+/**
   * @brief  ETH L4 filter structure definition
   */
-typedef struct{
+typedef struct
+{
   uint32_t Protocol;               /*!< Sets the L4 filter protocol to TCP or UDP
                                         This parameter can be a value of @ref ETHEx_L4_Protocol */
-  
+
   uint32_t SrcPortFilterMatch;     /*!< Sets the L4 filter source port match
                                         This parameter can be a value of @ref ETHEx_L4_Source_Match */
-  
+
   uint32_t DestPortFilterMatch;    /*!< Sets the L4 filter destination port match
                                         This parameter can be a value of @ref ETHEx_L4_Destination_Match */
-  
-  uint32_t SourcePort;             /*!< Sets the L4 filter source port 
+
+  uint32_t SourcePort;             /*!< Sets the L4 filter source port
                                         This parameter must be a value from 0x0 to 0xFFFF */
-  
-  uint32_t DestinationPort;        /*!< Sets the L4 filter destination port 
-                                        This parameter must be a value from 0x0 to 0xFFFF */	
-}ETH_L4FilterConfigTypeDef;
-/** 
-  * 
+
+  uint32_t DestinationPort;        /*!< Sets the L4 filter destination port
+                                        This parameter must be a value from 0x0 to 0xFFFF */
+} ETH_L4FilterConfigTypeDef;
+/**
+  *
   */
-  
+
 /**
   * @}
   */
-  
+
 /* Exported constants --------------------------------------------------------*/
 /** @defgroup ETHEx_Exported_Constants ETHEx Exported Constants
   * @{
   */
-    
+
 /** @defgroup ETHEx_LPI_Event ETHEx LPI Event
   * @{
-  */	
-#define ETH_TX_LPI_ENTRY    ETH_MACLCSR_TLPIEN 
-#define ETH_TX_LPI_EXIT     ETH_MACLCSR_TLPIEX 
+  */
+#define ETH_TX_LPI_ENTRY    ETH_MACLCSR_TLPIEN
+#define ETH_TX_LPI_EXIT     ETH_MACLCSR_TLPIEX
 #define ETH_RX_LPI_ENTRY    ETH_MACLCSR_RLPIEN
 #define ETH_RX_LPI_EXIT     ETH_MACLCSR_RLPIEX
 /**
   * @}
   */
-  
+
 /** @defgroup ETHEx_L3_Filter ETHEx L3 Filter
   * @{
   */
@@ -198,7 +202,7 @@ typedef struct{
 /**
   * @}
   */
-	
+
 /** @defgroup ETHEx_L3_Destination_Match ETHEx L3 Destination Match
   * @{
   */
@@ -208,7 +212,7 @@ typedef struct{
 /**
   * @}
   */
-	
+
 /** @defgroup ETHEx_L4_Protocol ETHEx L4 Protocol
   * @{
   */
@@ -217,17 +221,17 @@ typedef struct{
 /**
   * @}
   */
-	
+
 /** @defgroup ETHEx_L4_Source_Match ETHEx L4 Source Match
   * @{
   */
 #define ETH_L4_SRC_PORT_PERFECT_MATCH_ENABLE    ETH_MACL3L4CR_L4SPM
-#define ETH_L4_SRC_PORT_INVERSE_MATCH_ENABLE    (ETH_MACL3L4CR_L4SPM |ETH_MACL3L4CR_L4SPIM) 
+#define ETH_L4_SRC_PORT_INVERSE_MATCH_ENABLE    (ETH_MACL3L4CR_L4SPM |ETH_MACL3L4CR_L4SPIM)
 #define ETH_L4_SRC_PORT_MATCH_DISABLE           ((uint32_t)0x00000000)
 /**
   * @}
   */
-	
+
 /** @defgroup ETHEx_L4_Destination_Match ETHEx L4 Destination Match
   * @{
   */
@@ -237,10 +241,10 @@ typedef struct{
 /**
   * @}
   */
-  
+
 /** @defgroup ETHEx_Rx_Inner_VLAN_Tag_Stripping ETHEx Rx Inner VLAN Tag Stripping
   * @{
-  */ 
+  */
 #define ETH_INNERVLANTAGRXSTRIPPING_NONE      ETH_MACVTR_EIVLS_DONOTSTRIP
 #define ETH_INNERVLANTAGRXSTRIPPING_IFPASS    ETH_MACVTR_EIVLS_STRIPIFPASS
 #define ETH_INNERVLANTAGRXSTRIPPING_IFFAILS   ETH_MACVTR_EIVLS_STRIPIFFAILS
@@ -251,7 +255,7 @@ typedef struct{
 
 /** @defgroup ETHEx_Rx_VLAN_Tag_Stripping ETHEx Rx VLAN Tag Stripping
   * @{
-  */ 
+  */
 #define ETH_VLANTAGRXSTRIPPING_NONE      ETH_MACVTR_EVLS_DONOTSTRIP
 #define ETH_VLANTAGRXSTRIPPING_IFPASS    ETH_MACVTR_EVLS_STRIPIFPASS
 #define ETH_VLANTAGRXSTRIPPING_IFFAILS   ETH_MACVTR_EVLS_STRIPIFFAILS
@@ -259,17 +263,17 @@ typedef struct{
 /**
   * @}
   */
-  
+
 /** @defgroup ETHEx_VLAN_Type_Check ETHEx VLAN Type Check
   * @{
-  */ 
+  */
 #define ETH_VLANTYPECHECK_DISABLE    ETH_MACVTR_DOVLTC
 #define ETH_VLANTYPECHECK_SVLAN      (ETH_MACVTR_ERSVLM | ETH_MACVTR_ESVL)
 #define ETH_VLANTYPECHECK_CVLAN      ((uint32_t)0x00000000)
 /**
   * @}
   */
-  
+
 /** @defgroup ETHEx_VLAN_Tag_Control ETHEx_VLAN_Tag_Control
   * @{
   */
@@ -279,21 +283,21 @@ typedef struct{
 #define ETH_VLANTAGCONTROL_REPLACE    (ETH_MACVIR_VLP | ETH_MACVIR_VLC_VLANTAGREPLACE)
 /**
   * @}
-  */	
- 
+  */
+
 /** @defgroup ETHEx_Tx_VLAN_Tag ETHEx Tx VLAN Tag
   * @{
-  */ 
+  */
 #define ETH_INNER_TX_VLANTAG    ((uint32_t)0x00000001U)
 #define ETH_OUTER_TX_VLANTAG    ((uint32_t)0x00000000U)
 /**
   * @}
-  */ 
-  
+  */
+
 /**
   * @}
   */
-  
+
 /* Exported functions --------------------------------------------------------*/
 /** @addtogroup ETHEx_Exported_Functions
   * @{
@@ -305,15 +309,19 @@ typedef struct{
 /* MAC ARP Offloading APIs  ***************************************************/
 void              HAL_ETHEx_EnableARPOffload(ETH_HandleTypeDef *heth);
 void              HAL_ETHEx_DisableARPOffload(ETH_HandleTypeDef *heth);
-void              HAL_ETHEx_SetARPAddressMatch(ETH_HandleTypeDef *heth, uint32_t IpAddress); 
+void              HAL_ETHEx_SetARPAddressMatch(ETH_HandleTypeDef *heth, uint32_t IpAddress);
 
 /* MAC L3 L4 Filtering APIs ***************************************************/
 void              HAL_ETHEx_EnableL3L4Filtering(ETH_HandleTypeDef *heth);
 void              HAL_ETHEx_DisableL3L4Filtering(ETH_HandleTypeDef *heth);
-HAL_StatusTypeDef HAL_ETHEx_GetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter, ETH_L3FilterConfigTypeDef *pL3FilterConfig);
-HAL_StatusTypeDef HAL_ETHEx_GetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter, ETH_L4FilterConfigTypeDef *pL4FilterConfig);
-HAL_StatusTypeDef HAL_ETHEx_SetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter, ETH_L3FilterConfigTypeDef *pL3FilterConfig);
-HAL_StatusTypeDef HAL_ETHEx_SetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter, ETH_L4FilterConfigTypeDef *pL4FilterConfig);
+HAL_StatusTypeDef HAL_ETHEx_GetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
+                                              ETH_L3FilterConfigTypeDef *pL3FilterConfig);
+HAL_StatusTypeDef HAL_ETHEx_GetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
+                                              ETH_L4FilterConfigTypeDef *pL4FilterConfig);
+HAL_StatusTypeDef HAL_ETHEx_SetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
+                                              ETH_L3FilterConfigTypeDef *pL3FilterConfig);
+HAL_StatusTypeDef HAL_ETHEx_SetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
+                                              ETH_L4FilterConfigTypeDef *pL4FilterConfig);
 
 /* MAC VLAN Processing APIs    ************************************************/
 void              HAL_ETHEx_EnableVLANProcessing(ETH_HandleTypeDef *heth);
@@ -321,26 +329,29 @@ void              HAL_ETHEx_DisableVLANProcessing(ETH_HandleTypeDef *heth);
 HAL_StatusTypeDef HAL_ETHEx_GetRxVLANConfig(ETH_HandleTypeDef *heth, ETH_RxVLANConfigTypeDef *pVlanConfig);
 HAL_StatusTypeDef HAL_ETHEx_SetRxVLANConfig(ETH_HandleTypeDef *heth, ETH_RxVLANConfigTypeDef *pVlanConfig);
 void              HAL_ETHEx_SetVLANHashTable(ETH_HandleTypeDef *heth, uint32_t VLANHashTable);
-HAL_StatusTypeDef HAL_ETHEx_GetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VLANTag ,ETH_TxVLANConfigTypeDef *pVlanConfig);
-HAL_StatusTypeDef HAL_ETHEx_SetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VLANTag ,ETH_TxVLANConfigTypeDef *pVlanConfig);
-void              HAL_ETHEx_SetTxVLANIdentifier(ETH_HandleTypeDef *heth, uint32_t VLANTag ,uint32_t VLANIdentifier);
+HAL_StatusTypeDef HAL_ETHEx_GetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VLANTag,
+                                            ETH_TxVLANConfigTypeDef *pVlanConfig);
+HAL_StatusTypeDef HAL_ETHEx_SetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VLANTag,
+                                            ETH_TxVLANConfigTypeDef *pVlanConfig);
+void              HAL_ETHEx_SetTxVLANIdentifier(ETH_HandleTypeDef *heth, uint32_t VLANTag, uint32_t VLANIdentifier);
 
 /* Energy Efficient Ethernet APIs *********************************************/
-void              HAL_ETHEx_EnterLPIMode(ETH_HandleTypeDef *heth, FunctionalState TxAutomate, FunctionalState TxClockStop);
+void              HAL_ETHEx_EnterLPIMode(ETH_HandleTypeDef *heth, FunctionalState TxAutomate,
+                                         FunctionalState TxClockStop);
 void              HAL_ETHEx_ExitLPIMode(ETH_HandleTypeDef *heth);
 uint32_t          HAL_ETHEx_GetMACLPIEvent(ETH_HandleTypeDef *heth);
- 
-/**
-  * @}
-  */ 
 
 /**
   * @}
   */
-    
+
 /**
   * @}
-  */ 
+  */
+
+/**
+  * @}
+  */
 
 /**
   * @}
@@ -354,4 +365,4 @@ uint32_t          HAL_ETHEx_GetMACLPIEvent(ETH_HandleTypeDef *heth);
 
 #endif /* STM32H7xx_HAL_ETH_EX_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/Src/stm32h7xx_hal_eth.c
+++ b/Src/stm32h7xx_hal_eth.c
@@ -10,6 +10,17 @@
   *           + Peripheral Control functions
   *           + Peripheral State and Errors functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                     ##### How to use this driver #####
@@ -39,18 +50,14 @@
           (##) HAL_ETH_Start():
                This API starts the MAC and DMA transmission and reception process,
                without enabling end of transfer interrupts, in this mode user
-               has to poll for data availability by calling HAL_ETH_IsRxDataAvailable()
+               has to poll for data reception by calling HAL_ETH_ReadData()
           (##) HAL_ETH_Start_IT():
                This API starts the MAC and DMA transmission and reception process,
                end of transfer interrupts are enabled in this mode,
                HAL_ETH_RxCpltCallback() will be executed when an Ethernet packet is received
 
-      (#) When data is received (HAL_ETH_IsRxDataAvailable() returns 1 or Rx interrupt
-          occurred), user can call the following APIs to get received data:
-          (##) HAL_ETH_GetRxDataBuffer(): Get buffer address of received frame
-          (##) HAL_ETH_GetRxDataLength(): Get received frame length
-          (##) HAL_ETH_GetRxDataInfo(): Get received frame additional info,
-               please refer to ETH_RxPacketInfo typedef structure
+      (#) When data is received user can call the following API to get received data:
+          (##) HAL_ETH_ReadData(): Read a received packet
 
       (#) For transmission path, two APIs are available:
          (##) HAL_ETH_Transmit(): Transmit an ETH frame in blocking mode
@@ -69,20 +76,32 @@
           (##) HAL_ETH_GetDMAConfig(): Get DMA actual configuration into ETH_DMAConfigTypeDef
           (##) HAL_ETH_SetDMAConfig(): Set DMA configuration based on ETH_DMAConfigTypeDef
 
-      -@- The PTP protocol offload APIs are not supported in this driver.
+      (#) Configure the Ethernet PTP after ETH peripheral initialization
+          (##) Define HAL_ETH_USE_PTP to use PTP APIs.
+          (##) HAL_ETH_PTP_GetConfig(): Get PTP actual configuration into ETH_PTP_ConfigTypeDef
+          (##) HAL_ETH_PTP_SetConfig(): Set PTP configuration based on ETH_PTP_ConfigTypeDef
+          (##) HAL_ETH_PTP_GetTime(): Get Seconds and Nanoseconds for the Ethernet PTP registers
+          (##) HAL_ETH_PTP_SetTime(): Set Seconds and Nanoseconds for the Ethernet PTP registers
+          (##) HAL_ETH_PTP_AddTimeOffset(): Add Seconds and Nanoseconds offset for the Ethernet PTP registers
+          (##) HAL_ETH_PTP_InsertTxTimestamp(): Insert Timestamp in transmission
+          (##) HAL_ETH_PTP_GetTxTimestamp(): Get transmission timestamp
+          (##) HAL_ETH_PTP_GetRxTimestamp(): Get reception timestamp
+
+      -@- The ARP offload feature is not supported in this driver.
+
+      -@- The PTP offload feature is not supported in this driver.
 
   *** Callback registration ***
   =============================================
 
   The compilation define  USE_HAL_ETH_REGISTER_CALLBACKS when set to 1
   allows the user to configure dynamically the driver callbacks.
-  Use Function @ref HAL_ETH_RegisterCallback() to register an interrupt callback.
+  Use Function HAL_ETH_RegisterCallback() to register an interrupt callback.
 
-  Function @ref HAL_ETH_RegisterCallback() allows to register following callbacks:
+  Function HAL_ETH_RegisterCallback() allows to register following callbacks:
     (+) TxCpltCallback   : Tx Complete Callback.
     (+) RxCpltCallback   : Rx Complete Callback.
-    (+) DMAErrorCallback : DMA Error Callback.
-    (+) MACErrorCallback : MAC Error Callback.
+    (+) ErrorCallback    : Error Callback.
     (+) PMTCallback      : Power Management Callback
     (+) EEECallback      : EEE Callback.
     (+) WakeUpCallback   : Wake UP Callback
@@ -92,28 +111,51 @@
   This function takes as parameters the HAL peripheral handle, the Callback ID
   and a pointer to the user callback function.
 
-  Use function @ref HAL_ETH_UnRegisterCallback() to reset a callback to the default
+  For specific callbacks RxAllocateCallback use dedicated register callbacks:
+  respectively HAL_ETH_RegisterRxAllocateCallback().
+
+  For specific callbacks RxLinkCallback use dedicated register callbacks:
+  respectively HAL_ETH_RegisterRxLinkCallback().
+
+  For specific callbacks TxFreeCallback use dedicated register callbacks:
+  respectively HAL_ETH_RegisterTxFreeCallback().
+
+  For specific callbacks TxPtpCallback use dedicated register callbacks:
+  respectively HAL_ETH_RegisterTxPtpCallback().
+
+  Use function HAL_ETH_UnRegisterCallback() to reset a callback to the default
   weak function.
-  @ref HAL_ETH_UnRegisterCallback takes as parameters the HAL peripheral handle,
+  HAL_ETH_UnRegisterCallback takes as parameters the HAL peripheral handle,
   and the Callback ID.
   This function allows to reset following callbacks:
     (+) TxCpltCallback   : Tx Complete Callback.
     (+) RxCpltCallback   : Rx Complete Callback.
-    (+) DMAErrorCallback : DMA Error Callback.
-    (+) MACErrorCallback : MAC Error Callback.
+    (+) ErrorCallback    : Error Callback.
     (+) PMTCallback      : Power Management Callback
     (+) EEECallback      : EEE Callback.
     (+) WakeUpCallback   : Wake UP Callback
     (+) MspInitCallback  : MspInit Callback.
     (+) MspDeInitCallback: MspDeInit Callback.
 
+  For specific callbacks RxAllocateCallback use dedicated unregister callbacks:
+  respectively HAL_ETH_UnRegisterRxAllocateCallback().
+
+  For specific callbacks RxLinkCallback use dedicated unregister callbacks:
+  respectively HAL_ETH_UnRegisterRxLinkCallback().
+
+  For specific callbacks TxFreeCallback use dedicated unregister callbacks:
+  respectively HAL_ETH_UnRegisterTxFreeCallback().
+
+  For specific callbacks TxPtpCallback use dedicated unregister callbacks:
+  respectively HAL_ETH_UnRegisterTxPtpCallback().
+
   By default, after the HAL_ETH_Init and when the state is HAL_ETH_STATE_RESET
   all callbacks are set to the corresponding weak functions:
-  examples @ref HAL_ETH_TxCpltCallback(), @ref HAL_ETH_RxCpltCallback().
+  examples HAL_ETH_TxCpltCallback(), HAL_ETH_RxCpltCallback().
   Exception done for MspInit and MspDeInit functions that are
-  reset to the legacy weak function in the HAL_ETH_Init/ @ref HAL_ETH_DeInit only when
+  reset to the legacy weak function in the HAL_ETH_Init/ HAL_ETH_DeInit only when
   these callbacks are null (not registered beforehand).
-  if not, MspInit or MspDeInit are not null, the HAL_ETH_Init/ @ref HAL_ETH_DeInit
+  if not, MspInit or MspDeInit are not null, the HAL_ETH_Init/ HAL_ETH_DeInit
   keep and use the user MspInit/MspDeInit callbacks (registered beforehand)
 
   Callbacks can be registered/unregistered in HAL_ETH_STATE_READY state only.
@@ -121,7 +163,7 @@
   in HAL_ETH_STATE_READY or HAL_ETH_STATE_RESET state,
   thus registered (user) MspInit/DeInit callbacks can be used during the Init/DeInit.
   In that case first register the MspInit/MspDeInit user callbacks
-  using @ref HAL_ETH_RegisterCallback() before calling @ref HAL_ETH_DeInit
+  using HAL_ETH_RegisterCallback() before calling HAL_ETH_DeInit
   or HAL_ETH_Init function.
 
   When The compilation define USE_HAL_ETH_REGISTER_CALLBACKS is set to 0 or
@@ -129,17 +171,6 @@
   are set to the corresponding weak functions.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -182,14 +213,15 @@
                               ETH_MACPCSR_RWKPFE)
 
 /* Timeout values */
-#define ETH_SWRESET_TIMEOUT                 ((uint32_t)500U)
-#define ETH_MDIO_BUS_TIMEOUT                ((uint32_t)1000U)
-
 #define ETH_DMARXNDESCWBF_ERRORS_MASK ((uint32_t)(ETH_DMARXNDESCWBF_DE | ETH_DMARXNDESCWBF_RE | \
                                                   ETH_DMARXNDESCWBF_OE | ETH_DMARXNDESCWBF_RWT |\
                                                   ETH_DMARXNDESCWBF_GP | ETH_DMARXNDESCWBF_CE))
 
-#define ETH_MAC_US_TICK               ((uint32_t)1000000U)
+#define ETH_MACTSCR_MASK              ((uint32_t)0x0087FF2FU)
+
+#define ETH_MACSTSUR_VALUE            ((uint32_t)0xFFFFFFFFU)
+#define ETH_MACSTNUR_VALUE            ((uint32_t)0xBB9ACA00U)
+#define ETH_SEGMENT_SIZE_DEFAULT      ((uint32_t)0x218U)
 /**
   * @}
   */
@@ -200,17 +232,17 @@
   */
 /* Helper macros for TX descriptor handling */
 #define INCR_TX_DESC_INDEX(inx, offset) do {\
-	(inx) += (offset);\
-          if ((inx) >= (uint32_t)ETH_TX_DESC_CNT){\
-            (inx) = ((inx) - (uint32_t)ETH_TX_DESC_CNT);}\
-} while (0)
+                                             (inx) += (offset);\
+                                             if ((inx) >= (uint32_t)ETH_TX_DESC_CNT){\
+                                             (inx) = ((inx) - (uint32_t)ETH_TX_DESC_CNT);}\
+                                           } while (0)
 
 /* Helper macros for RX descriptor handling */
 #define INCR_RX_DESC_INDEX(inx, offset) do {\
-	(inx) += (offset);\
-          if ((inx) >= (uint32_t)ETH_RX_DESC_CNT){\
-            (inx) = ((inx) - (uint32_t)ETH_RX_DESC_CNT);}\
-} while (0)
+                                             (inx) += (offset);\
+                                             if ((inx) >= (uint32_t)ETH_RX_DESC_CNT){\
+                                             (inx) = ((inx) - (uint32_t)ETH_RX_DESC_CNT);}\
+                                           } while (0)
 /**
   * @}
   */
@@ -218,13 +250,13 @@
 /** @defgroup ETH_Private_Functions   ETH Private Functions
   * @{
   */
-static void ETH_MAC_MDIO_ClkConfig(ETH_HandleTypeDef *heth);
 static void ETH_SetMACConfig(ETH_HandleTypeDef *heth,  ETH_MACConfigTypeDef *macconf);
 static void ETH_SetDMAConfig(ETH_HandleTypeDef *heth,  ETH_DMAConfigTypeDef *dmaconf);
 static void ETH_MACDMAConfig(ETH_HandleTypeDef *heth);
 static void ETH_DMATxDescListInit(ETH_HandleTypeDef *heth);
 static void ETH_DMARxDescListInit(ETH_HandleTypeDef *heth);
 static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig, uint32_t ItMode);
+static void ETH_UpdateDescriptor(ETH_HandleTypeDef *heth);
 
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
 static void ETH_InitCallbacksToDefault(ETH_HandleTypeDef *heth);
@@ -259,9 +291,6 @@ static void ETH_InitCallbacksToDefault(ETH_HandleTypeDef *heth);
         (++) Tx DMA Descriptors Tab
         (++) Length of Rx Buffers
 
-      (+) Call the function HAL_ETH_DescAssignMemory() to assign data buffers
-          for each Rx DMA Descriptor
-
       (+) Call the function HAL_ETH_DeInit() to restore the default configuration
           of the selected ETH peripheral.
 
@@ -279,44 +308,35 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
 {
   uint32_t tickstart;
 
-  if(heth == NULL)
+  if (heth == NULL)
   {
     return HAL_ERROR;
   }
+  if (heth->gState == HAL_ETH_STATE_RESET)
+  {
+    heth->gState = HAL_ETH_STATE_BUSY;
 
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
 
-  if(heth->gState == HAL_ETH_STATE_RESET)
-  {
-    /* Allocate lock resource and initialize it */
-    heth->Lock = HAL_UNLOCKED;
-
     ETH_InitCallbacksToDefault(heth);
 
-    if(heth->MspInitCallback == NULL)
+    if (heth->MspInitCallback == NULL)
     {
       heth->MspInitCallback = HAL_ETH_MspInit;
     }
 
     /* Init the low level hardware */
     heth->MspInitCallback(heth);
-  }
-
 #else
-
-  /* Check the ETH peripheral state */
-  if(heth->gState == HAL_ETH_STATE_RESET)
-  {
     /* Init the low level hardware : GPIO, CLOCK, NVIC. */
     HAL_ETH_MspInit(heth);
-  }
-#endif /* (USE_HAL_ETH_REGISTER_CALLBACKS) */
 
-  heth->gState = HAL_ETH_STATE_BUSY;
+#endif /* (USE_HAL_ETH_REGISTER_CALLBACKS) */
+  }
 
   __HAL_RCC_SYSCFG_CLK_ENABLE();
 
-  if(heth->Init.MediaInterface == HAL_ETH_MII_MODE)
+  if (heth->Init.MediaInterface == HAL_ETH_MII_MODE)
   {
     HAL_SYSCFG_ETHInterfaceSelect(SYSCFG_ETH_MII);
   }
@@ -324,6 +344,9 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
   {
     HAL_SYSCFG_ETHInterfaceSelect(SYSCFG_ETH_RMII);
   }
+
+  /* Dummy read to sync with ETH */
+  (void)SYSCFG->PMCR;
 
   /* Ethernet Software reset */
   /* Set the SWR bit: resets all MAC subsystem internal registers and logic */
@@ -336,7 +359,7 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
   /* Wait for software reset */
   while (READ_BIT(heth->Instance->DMAMR, ETH_DMAMR_SWR) > 0U)
   {
-    if(((HAL_GetTick() - tickstart ) > ETH_SWRESET_TIMEOUT))
+    if (((HAL_GetTick() - tickstart) > ETH_SWRESET_TIMEOUT))
     {
       /* Set Error Code */
       heth->ErrorCode = HAL_ETH_ERROR_TIMEOUT;
@@ -348,7 +371,7 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
   }
 
   /*------------------ MDIO CSR Clock Range Configuration --------------------*/
-  ETH_MAC_MDIO_ClkConfig(heth);
+  HAL_ETH_SetMDIOClockRange(heth);
 
   /*------------------ MAC LPI 1US Tic Counter Configuration --------------------*/
   WRITE_REG(heth->Instance->MAC1USTCR, (((uint32_t)HAL_RCC_GetHCLKFreq() / ETH_MAC_US_TICK) - 1U));
@@ -389,7 +412,6 @@ HAL_StatusTypeDef HAL_ETH_Init(ETH_HandleTypeDef *heth)
 
   heth->ErrorCode = HAL_ETH_ERROR_NONE;
   heth->gState = HAL_ETH_STATE_READY;
-  heth->RxState = HAL_ETH_STATE_READY;
 
   return HAL_OK;
 }
@@ -407,7 +429,7 @@ HAL_StatusTypeDef HAL_ETH_DeInit(ETH_HandleTypeDef *heth)
 
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
 
-  if(heth->MspDeInitCallback == NULL)
+  if (heth->MspDeInitCallback == NULL)
   {
     heth->MspDeInitCallback = HAL_ETH_MspDeInit;
   }
@@ -421,7 +443,7 @@ HAL_StatusTypeDef HAL_ETH_DeInit(ETH_HandleTypeDef *heth)
 #endif /* (USE_HAL_ETH_REGISTER_CALLBACKS) */
 
   /* Set ETH HAL state to Disabled */
-  heth->gState= HAL_ETH_STATE_RESET;
+  heth->gState = HAL_ETH_STATE_RESET;
 
   /* Return function status */
   return HAL_OK;
@@ -466,8 +488,7 @@ __weak void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
   *        This parameter can be one of the following values:
   *          @arg @ref HAL_ETH_TX_COMPLETE_CB_ID Tx Complete Callback ID
   *          @arg @ref HAL_ETH_RX_COMPLETE_CB_ID Rx Complete Callback ID
-  *          @arg @ref HAL_ETH_DMA_ERROR_CB_ID   DMA Error Callback ID
-  *          @arg @ref HAL_ETH_MAC_ERROR_CB_ID   MAC Error Callback ID
+  *          @arg @ref HAL_ETH_ERROR_CB_ID       Error Callback ID
   *          @arg @ref HAL_ETH_PMT_CB_ID         Power Management Callback ID
   *          @arg @ref HAL_ETH_EEE_CB_ID         EEE Callback ID
   *          @arg @ref HAL_ETH_WAKEUP_CB_ID      Wake UP Callback ID
@@ -476,86 +497,81 @@ __weak void HAL_ETH_MspDeInit(ETH_HandleTypeDef *heth)
   * @param pCallback pointer to the Callback function
   * @retval status
   */
-HAL_StatusTypeDef HAL_ETH_RegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_CallbackIDTypeDef CallbackID, pETH_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_ETH_RegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_CallbackIDTypeDef CallbackID,
+                                           pETH_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  if(pCallback == NULL)
+  if (pCallback == NULL)
   {
     /* Update the error code */
     heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
 
     return HAL_ERROR;
   }
-  /* Process locked */
-  __HAL_LOCK(heth);
 
-  if(heth->gState == HAL_ETH_STATE_READY)
+  if (heth->gState == HAL_ETH_STATE_READY)
   {
     switch (CallbackID)
     {
-    case HAL_ETH_TX_COMPLETE_CB_ID :
-      heth->TxCpltCallback = pCallback;
-      break;
+      case HAL_ETH_TX_COMPLETE_CB_ID :
+        heth->TxCpltCallback = pCallback;
+        break;
 
-    case HAL_ETH_RX_COMPLETE_CB_ID :
-      heth->RxCpltCallback = pCallback;
-      break;
+      case HAL_ETH_RX_COMPLETE_CB_ID :
+        heth->RxCpltCallback = pCallback;
+        break;
 
-    case HAL_ETH_DMA_ERROR_CB_ID :
-      heth->DMAErrorCallback = pCallback;
-      break;
+      case HAL_ETH_ERROR_CB_ID :
+        heth->ErrorCallback = pCallback;
+        break;
 
-    case HAL_ETH_MAC_ERROR_CB_ID :
-      heth->MACErrorCallback = pCallback;
-      break;
+      case HAL_ETH_PMT_CB_ID :
+        heth->PMTCallback = pCallback;
+        break;
 
-    case HAL_ETH_PMT_CB_ID :
-      heth->PMTCallback = pCallback;
-      break;
+      case HAL_ETH_EEE_CB_ID :
+        heth->EEECallback = pCallback;
+        break;
 
-    case HAL_ETH_EEE_CB_ID :
-      heth->EEECallback = pCallback;
-      break;
+      case HAL_ETH_WAKEUP_CB_ID :
+        heth->WakeUpCallback = pCallback;
+        break;
 
-    case HAL_ETH_WAKEUP_CB_ID :
-      heth->WakeUpCallback = pCallback;
-      break;
+      case HAL_ETH_MSPINIT_CB_ID :
+        heth->MspInitCallback = pCallback;
+        break;
 
-    case HAL_ETH_MSPINIT_CB_ID :
-      heth->MspInitCallback = pCallback;
-      break;
+      case HAL_ETH_MSPDEINIT_CB_ID :
+        heth->MspDeInitCallback = pCallback;
+        break;
 
-   case HAL_ETH_MSPDEINIT_CB_ID :
-      heth->MspDeInitCallback = pCallback;
-      break;
-
-    default :
-      /* Update the error code */
-      heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
-      /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      default :
+        /* Update the error code */
+        heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
-  else if(heth->gState == HAL_ETH_STATE_RESET)
+  else if (heth->gState == HAL_ETH_STATE_RESET)
   {
     switch (CallbackID)
     {
-    case HAL_ETH_MSPINIT_CB_ID :
-      heth->MspInitCallback = pCallback;
-      break;
+      case HAL_ETH_MSPINIT_CB_ID :
+        heth->MspInitCallback = pCallback;
+        break;
 
-   case HAL_ETH_MSPDEINIT_CB_ID :
-      heth->MspDeInitCallback = pCallback;
-      break;
+      case HAL_ETH_MSPDEINIT_CB_ID :
+        heth->MspDeInitCallback = pCallback;
+        break;
 
-    default :
-      /* Update the error code */
-      heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
-     /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      default :
+        /* Update the error code */
+        heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
   else
@@ -565,9 +581,6 @@ HAL_StatusTypeDef HAL_ETH_RegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_Call
     /* Return error status */
     status =  HAL_ERROR;
   }
-
-  /* Release Lock */
-  __HAL_UNLOCK(heth);
 
   return status;
 }
@@ -580,8 +593,7 @@ HAL_StatusTypeDef HAL_ETH_RegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_Call
   *        This parameter can be one of the following values:
   *          @arg @ref HAL_ETH_TX_COMPLETE_CB_ID Tx Complete Callback ID
   *          @arg @ref HAL_ETH_RX_COMPLETE_CB_ID Rx Complete Callback ID
-  *          @arg @ref HAL_ETH_DMA_ERROR_CB_ID   DMA Error Callback ID
-  *          @arg @ref HAL_ETH_MAC_ERROR_CB_ID   MAC Error Callback ID
+  *          @arg @ref HAL_ETH_ERROR_CB_ID       Error Callback ID
   *          @arg @ref HAL_ETH_PMT_CB_ID         Power Management Callback ID
   *          @arg @ref HAL_ETH_EEE_CB_ID         EEE Callback ID
   *          @arg @ref HAL_ETH_WAKEUP_CB_ID      Wake UP Callback ID
@@ -593,75 +605,68 @@ HAL_StatusTypeDef HAL_ETH_UnRegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_Ca
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  /* Process locked */
-  __HAL_LOCK(heth);
-
-  if(heth->gState == HAL_ETH_STATE_READY)
+  if (heth->gState == HAL_ETH_STATE_READY)
   {
     switch (CallbackID)
     {
-    case HAL_ETH_TX_COMPLETE_CB_ID :
-      heth->TxCpltCallback = HAL_ETH_TxCpltCallback;
-      break;
+      case HAL_ETH_TX_COMPLETE_CB_ID :
+        heth->TxCpltCallback = HAL_ETH_TxCpltCallback;
+        break;
 
-    case HAL_ETH_RX_COMPLETE_CB_ID :
-      heth->RxCpltCallback = HAL_ETH_RxCpltCallback;
-      break;
+      case HAL_ETH_RX_COMPLETE_CB_ID :
+        heth->RxCpltCallback = HAL_ETH_RxCpltCallback;
+        break;
 
-    case HAL_ETH_DMA_ERROR_CB_ID :
-      heth->DMAErrorCallback = HAL_ETH_DMAErrorCallback;
-      break;
+      case HAL_ETH_ERROR_CB_ID :
+        heth->ErrorCallback = HAL_ETH_ErrorCallback;
+        break;
 
-    case HAL_ETH_MAC_ERROR_CB_ID :
-      heth->MACErrorCallback = HAL_ETH_MACErrorCallback;
-      break;
+      case HAL_ETH_PMT_CB_ID :
+        heth->PMTCallback = HAL_ETH_PMTCallback;
+        break;
 
-    case HAL_ETH_PMT_CB_ID :
-      heth->PMTCallback = HAL_ETH_PMTCallback;
-      break;
+      case HAL_ETH_EEE_CB_ID :
+        heth->EEECallback = HAL_ETH_EEECallback;
+        break;
 
-    case HAL_ETH_EEE_CB_ID :
-      heth->EEECallback = HAL_ETH_EEECallback;
-      break;
+      case HAL_ETH_WAKEUP_CB_ID :
+        heth->WakeUpCallback = HAL_ETH_WakeUpCallback;
+        break;
 
-    case HAL_ETH_WAKEUP_CB_ID :
-      heth->WakeUpCallback = HAL_ETH_WakeUpCallback;
-      break;
+      case HAL_ETH_MSPINIT_CB_ID :
+        heth->MspInitCallback = HAL_ETH_MspInit;
+        break;
 
-    case HAL_ETH_MSPINIT_CB_ID :
-      heth->MspInitCallback = HAL_ETH_MspInit;
-      break;
+      case HAL_ETH_MSPDEINIT_CB_ID :
+        heth->MspDeInitCallback = HAL_ETH_MspDeInit;
+        break;
 
-   case HAL_ETH_MSPDEINIT_CB_ID :
-      heth->MspDeInitCallback = HAL_ETH_MspDeInit;
-      break;
-
-    default :
-      /* Update the error code */
-      heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
-     /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      default :
+        /* Update the error code */
+        heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
-  else if(heth->gState == HAL_ETH_STATE_RESET)
+  else if (heth->gState == HAL_ETH_STATE_RESET)
   {
     switch (CallbackID)
     {
-    case HAL_ETH_MSPINIT_CB_ID :
-      heth->MspInitCallback = HAL_ETH_MspInit;
-      break;
+      case HAL_ETH_MSPINIT_CB_ID :
+        heth->MspInitCallback = HAL_ETH_MspInit;
+        break;
 
-   case HAL_ETH_MSPDEINIT_CB_ID :
-      heth->MspDeInitCallback = HAL_ETH_MspDeInit;
-      break;
+      case HAL_ETH_MSPDEINIT_CB_ID :
+        heth->MspDeInitCallback = HAL_ETH_MspDeInit;
+        break;
 
-    default :
-      /* Update the error code */
-      heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
-     /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      default :
+        /* Update the error code */
+        heth->ErrorCode |= HAL_ETH_ERROR_INVALID_CALLBACK;
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
   else
@@ -672,56 +677,9 @@ HAL_StatusTypeDef HAL_ETH_UnRegisterCallback(ETH_HandleTypeDef *heth, HAL_ETH_Ca
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(heth);
-
   return status;
 }
 #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
-
-/**
-  * @brief  Assign memory buffers to a DMA Rx descriptor
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @param  Index : index of the DMA Rx descriptor
-  *                  this parameter can be a value from 0x0 to (ETH_RX_DESC_CNT -1)
-  * @param  pBuffer1: address of buffer 1
-  * @param  pBuffer2: address of buffer 2 if available
-  * @retval HAL status
-  */
-HAL_StatusTypeDef HAL_ETH_DescAssignMemory(ETH_HandleTypeDef *heth, uint32_t Index, uint8_t *pBuffer1, uint8_t *pBuffer2)
-{
-  ETH_DMADescTypeDef *dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[Index];
-
-  if((pBuffer1 == NULL) || (Index >= (uint32_t)ETH_RX_DESC_CNT))
-  {
-    /* Set Error Code */
-    heth->ErrorCode = HAL_ETH_ERROR_PARAM;
-    /* Return Error */
-    return HAL_ERROR;
-  }
-
-  /* write buffer address to RDES0 */
-  WRITE_REG(dmarxdesc->DESC0, (uint32_t)pBuffer1);
-  /* store buffer address */
-  WRITE_REG(dmarxdesc->BackupAddr0, (uint32_t)pBuffer1);
-  /* set buffer address valid bit to RDES3 */
-  SET_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCRF_BUF1V);
-
-  if(pBuffer2 != NULL)
-  {
-    /* write buffer 2 address to RDES1 */
-    WRITE_REG(dmarxdesc->DESC2, (uint32_t)pBuffer2);
-     /* store buffer 2 address */
-    WRITE_REG(dmarxdesc->BackupAddr1, (uint32_t)pBuffer2);
-    /* set buffer 2 address valid bit to RDES3 */
-    SET_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCRF_BUF2V);
-  }
-  /* set OWN bit to RDES3 */
-  SET_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCRF_OWN);
-
-  return HAL_OK;
-}
 
 /**
   * @}
@@ -750,9 +708,15 @@ HAL_StatusTypeDef HAL_ETH_DescAssignMemory(ETH_HandleTypeDef *heth, uint32_t Ind
   */
 HAL_StatusTypeDef HAL_ETH_Start(ETH_HandleTypeDef *heth)
 {
-  if(heth->gState == HAL_ETH_STATE_READY)
+  if (heth->gState == HAL_ETH_STATE_READY)
   {
     heth->gState = HAL_ETH_STATE_BUSY;
+
+    /* Set nombre of descriptors to build */
+    heth->RxDescList.RxBuildDescCnt = ETH_RX_DESC_CNT;
+
+    /* Build all descriptors */
+    ETH_UpdateDescriptor(heth);
 
     /* Enable the MAC transmission */
     SET_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
@@ -772,8 +736,7 @@ HAL_StatusTypeDef HAL_ETH_Start(ETH_HandleTypeDef *heth)
     /* Clear Tx and Rx process stopped flags */
     heth->Instance->DMACSR |= (ETH_DMACSR_TPS | ETH_DMACSR_RPS);
 
-    heth->gState = HAL_ETH_STATE_READY;
-    heth->RxState = HAL_ETH_STATE_BUSY_RX;
+    heth->gState = HAL_ETH_STATE_STARTED;
 
     return HAL_OK;
   }
@@ -791,23 +754,25 @@ HAL_StatusTypeDef HAL_ETH_Start(ETH_HandleTypeDef *heth)
   */
 HAL_StatusTypeDef HAL_ETH_Start_IT(ETH_HandleTypeDef *heth)
 {
-  uint32_t descindex;
-
-  ETH_DMADescTypeDef *dmarxdesc;
-
-  if(heth->gState == HAL_ETH_STATE_READY)
+  if (heth->gState == HAL_ETH_STATE_READY)
   {
     heth->gState = HAL_ETH_STATE_BUSY;
 
-    /* Set IOC bit to all Rx descriptors */
-    for(descindex = 0; descindex < (uint32_t)ETH_RX_DESC_CNT; descindex++)
-    {
-      dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descindex];
-      SET_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCRF_IOC);
-    }
-
     /* save IT mode to ETH Handle */
     heth->RxDescList.ItMode = 1U;
+    /* Disable Rx MMC Interrupts */
+    SET_BIT(heth->Instance->MMCRIMR, ETH_MMCRIMR_RXLPITRCIM | ETH_MMCRIMR_RXLPIUSCIM | \
+            ETH_MMCRIMR_RXUCGPIM | ETH_MMCRIMR_RXALGNERPIM | ETH_MMCRIMR_RXCRCERPIM);
+
+    /* Disable Tx MMC Interrupts */
+    SET_BIT(heth->Instance->MMCTIMR, ETH_MMCTIMR_TXLPITRCIM | ETH_MMCTIMR_TXLPIUSCIM | \
+            ETH_MMCTIMR_TXGPKTIM | ETH_MMCTIMR_TXMCOLGPIM | ETH_MMCTIMR_TXSCOLGPIM);
+
+    /* Set nombre of descriptors to build */
+    heth->RxDescList.RxBuildDescCnt = ETH_RX_DESC_CNT;
+
+    /* Build all descriptors */
+    ETH_UpdateDescriptor(heth);
 
     /* Enable the MAC transmission */
     SET_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
@@ -833,11 +798,9 @@ HAL_StatusTypeDef HAL_ETH_Start_IT(ETH_HandleTypeDef *heth)
     - Fatal bus interrupt
     */
     __HAL_ETH_DMA_ENABLE_IT(heth, (ETH_DMACIER_NIE | ETH_DMACIER_RIE | ETH_DMACIER_TIE  |
-                                   ETH_DMACIER_FBEE | ETH_DMACIER_AIE));
+                                   ETH_DMACIER_FBEE | ETH_DMACIER_AIE | ETH_DMACIER_RBUE));
 
-    heth->gState = HAL_ETH_STATE_READY;
-    heth->RxState = HAL_ETH_STATE_BUSY_RX;
-
+    heth->gState = HAL_ETH_STATE_STARTED;
     return HAL_OK;
   }
   else
@@ -854,11 +817,10 @@ HAL_StatusTypeDef HAL_ETH_Start_IT(ETH_HandleTypeDef *heth)
   */
 HAL_StatusTypeDef HAL_ETH_Stop(ETH_HandleTypeDef *heth)
 {
-  if(heth->gState != HAL_ETH_STATE_RESET)
+  if (heth->gState == HAL_ETH_STATE_STARTED)
   {
-     /* Set the ETH peripheral state to BUSY */
+    /* Set the ETH peripheral state to BUSY */
     heth->gState = HAL_ETH_STATE_BUSY;
-
     /* Disable the DMA transmission */
     CLEAR_BIT(heth->Instance->DMACTCR, ETH_DMACTCR_ST);
 
@@ -866,7 +828,7 @@ HAL_StatusTypeDef HAL_ETH_Stop(ETH_HandleTypeDef *heth)
     CLEAR_BIT(heth->Instance->DMACRCR, ETH_DMACRCR_SR);
 
     /* Disable the MAC reception */
-    CLEAR_BIT( heth->Instance->MACCR, ETH_MACCR_RE);
+    CLEAR_BIT(heth->Instance->MACCR, ETH_MACCR_RE);
 
     /* Set the Flush Transmit FIFO bit */
     SET_BIT(heth->Instance->MTLTQOMR, ETH_MTLTQOMR_FTQ);
@@ -875,7 +837,6 @@ HAL_StatusTypeDef HAL_ETH_Stop(ETH_HandleTypeDef *heth)
     CLEAR_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
 
     heth->gState = HAL_ETH_STATE_READY;
-    heth->RxState = HAL_ETH_STATE_READY;
 
     /* Return function status */
     return HAL_OK;
@@ -897,7 +858,7 @@ HAL_StatusTypeDef HAL_ETH_Stop_IT(ETH_HandleTypeDef *heth)
   ETH_DMADescTypeDef *dmarxdesc;
   uint32_t descindex;
 
-  if(heth->gState != HAL_ETH_STATE_RESET)
+  if (heth->gState == HAL_ETH_STATE_STARTED)
   {
     /* Set the ETH peripheral state to BUSY */
     heth->gState = HAL_ETH_STATE_BUSY;
@@ -908,7 +869,7 @@ HAL_StatusTypeDef HAL_ETH_Stop_IT(ETH_HandleTypeDef *heth)
     - Fatal bus interrupt
     */
     __HAL_ETH_DMA_DISABLE_IT(heth, (ETH_DMACIER_NIE | ETH_DMACIER_RIE | ETH_DMACIER_TIE  |
-                                   ETH_DMACIER_FBEE | ETH_DMACIER_AIE));
+                                    ETH_DMACIER_FBEE | ETH_DMACIER_AIE | ETH_DMACIER_RBUE));
 
     /* Disable the DMA transmission */
     CLEAR_BIT(heth->Instance->DMACTCR, ETH_DMACTCR_ST);
@@ -917,8 +878,7 @@ HAL_StatusTypeDef HAL_ETH_Stop_IT(ETH_HandleTypeDef *heth)
     CLEAR_BIT(heth->Instance->DMACRCR, ETH_DMACRCR_SR);
 
     /* Disable the MAC reception */
-    CLEAR_BIT( heth->Instance->MACCR, ETH_MACCR_RE);
-
+    CLEAR_BIT(heth->Instance->MACCR, ETH_MACCR_RE);
     /* Set the Flush Transmit FIFO bit */
     SET_BIT(heth->Instance->MTLTQOMR, ETH_MTLTQOMR_FTQ);
 
@@ -926,7 +886,7 @@ HAL_StatusTypeDef HAL_ETH_Stop_IT(ETH_HandleTypeDef *heth)
     CLEAR_BIT(heth->Instance->MACCR, ETH_MACCR_TE);
 
     /* Clear IOC bit to all Rx descriptors */
-    for(descindex = 0; descindex < (uint32_t)ETH_RX_DESC_CNT; descindex++)
+    for (descindex = 0; descindex < (uint32_t)ETH_RX_DESC_CNT; descindex++)
     {
       dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descindex];
       CLEAR_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCRF_IOC);
@@ -935,7 +895,6 @@ HAL_StatusTypeDef HAL_ETH_Stop_IT(ETH_HandleTypeDef *heth)
     heth->RxDescList.ItMode = 0U;
 
     heth->gState = HAL_ETH_STATE_READY;
-    heth->RxState = HAL_ETH_STATE_READY;
 
     /* Return function status */
     return HAL_OK;
@@ -957,15 +916,15 @@ HAL_StatusTypeDef HAL_ETH_Stop_IT(ETH_HandleTypeDef *heth)
 HAL_StatusTypeDef HAL_ETH_Transmit(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig, uint32_t Timeout)
 {
   uint32_t tickstart;
-  const ETH_DMADescTypeDef *dmatxdesc;
+  ETH_DMADescTypeDef *dmatxdesc;
 
-  if(pTxConfig == NULL)
+  if (pTxConfig == NULL)
   {
     heth->ErrorCode |= HAL_ETH_ERROR_PARAM;
     return HAL_ERROR;
   }
 
-  if(heth->gState == HAL_ETH_STATE_READY)
+  if (heth->gState == HAL_ETH_STATE_STARTED)
   {
     /* Config DMA Tx descriptor by Tx Packet info */
     if (ETH_Prepare_Tx_Descriptors(heth, pTxConfig, 0) != HAL_ETH_ERROR_NONE)
@@ -974,6 +933,9 @@ HAL_StatusTypeDef HAL_ETH_Transmit(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *
       heth->ErrorCode |= HAL_ETH_ERROR_BUSY;
       return HAL_ERROR;
     }
+
+    /* Ensure completion of descriptor preparation before transmission start */
+    __DSB();
 
     dmatxdesc = (ETH_DMADescTypeDef *)(&heth->TxDescList)->TxDesc[heth->TxDescList.CurTxDesc];
 
@@ -987,25 +949,24 @@ HAL_StatusTypeDef HAL_ETH_Transmit(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *
     tickstart = HAL_GetTick();
 
     /* Wait for data to be transmitted or timeout occurred */
-    while((dmatxdesc->DESC3 & ETH_DMATXNDESCWBF_OWN) != (uint32_t)RESET)
+    while ((dmatxdesc->DESC3 & ETH_DMATXNDESCWBF_OWN) != (uint32_t)RESET)
     {
-      if((heth->Instance->DMACSR & ETH_DMACSR_FBE) != (uint32_t)RESET)
+      if ((heth->Instance->DMACSR & ETH_DMACSR_FBE) != (uint32_t)RESET)
       {
         heth->ErrorCode |= HAL_ETH_ERROR_DMA;
         heth->DMAErrorCode = heth->Instance->DMACSR;
-        /* Set ETH HAL State to Ready */
-        heth->gState = HAL_ETH_STATE_ERROR;
         /* Return function status */
         return HAL_ERROR;
       }
 
       /* Check for the Timeout */
-      if(Timeout != HAL_MAX_DELAY)
+      if (Timeout != HAL_MAX_DELAY)
       {
-        if(((HAL_GetTick() - tickstart ) > Timeout) || (Timeout == 0U))
+        if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0U))
         {
           heth->ErrorCode |= HAL_ETH_ERROR_TIMEOUT;
-          heth->gState = HAL_ETH_STATE_ERROR;
+          /* Clear TX descriptor so that we can proceed */
+          dmatxdesc->DESC3 = (ETH_DMATXNDESCWBF_FD | ETH_DMATXNDESCWBF_LD);
           return HAL_ERROR;
         }
       }
@@ -1029,20 +990,26 @@ HAL_StatusTypeDef HAL_ETH_Transmit(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *
   */
 HAL_StatusTypeDef HAL_ETH_Transmit_IT(ETH_HandleTypeDef *heth, ETH_TxPacketConfig *pTxConfig)
 {
-  if(pTxConfig == NULL)
+  if (pTxConfig == NULL)
   {
     heth->ErrorCode |= HAL_ETH_ERROR_PARAM;
     return HAL_ERROR;
   }
 
-  if(heth->gState == HAL_ETH_STATE_READY)
+  if (heth->gState == HAL_ETH_STATE_STARTED)
   {
+    /* Save the packet pointer to release.  */
+    heth->TxDescList.CurrentPacketAddress = (uint32_t *)pTxConfig->pData;
+
     /* Config DMA Tx descriptor by Tx Packet info */
     if (ETH_Prepare_Tx_Descriptors(heth, pTxConfig, 1) != HAL_ETH_ERROR_NONE)
     {
       heth->ErrorCode |= HAL_ETH_ERROR_BUSY;
       return HAL_ERROR;
     }
+
+    /* Ensure completion of descriptor preparation before transmission start */
+    __DSB();
 
     /* Incr current tx desc index */
     INCR_TX_DESC_INDEX(heth->TxDescList.CurTxDesc, 1U);
@@ -1061,410 +1028,800 @@ HAL_StatusTypeDef HAL_ETH_Transmit_IT(ETH_HandleTypeDef *heth, ETH_TxPacketConfi
 }
 
 /**
-  * @brief  Checks for received Packets.
+  * @brief  Read a received packet.
   * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
-  * @retval  1: A Packet is received
-  *          0: no Packet received
+  * @param  pAppBuff: Pointer to an application buffer to receive the packet.
+  * @retval HAL status
   */
-uint8_t HAL_ETH_IsRxDataAvailable(ETH_HandleTypeDef *heth)
+HAL_StatusTypeDef HAL_ETH_ReadData(ETH_HandleTypeDef *heth, void **pAppBuff)
 {
-  ETH_RxDescListTypeDef *dmarxdesclist = &heth->RxDescList;
-  uint32_t descidx = dmarxdesclist->CurRxDesc;
-  ETH_DMADescTypeDef *dmarxdesc = (ETH_DMADescTypeDef *)dmarxdesclist->RxDesc[descidx];
-  uint32_t descscancnt = 0;
-  uint32_t appdesccnt = 0, firstappdescidx = 0;
+  uint32_t descidx;
+  ETH_DMADescTypeDef *dmarxdesc;
+  uint32_t desccnt = 0U;
+  uint32_t desccntmax;
+  uint32_t bufflength;
+  uint8_t rxdataready = 0U;
 
-  if(dmarxdesclist->AppDescNbr != 0U)
+
+  if (pAppBuff == NULL)
   {
-    /* data already received by not yet processed*/
-    return 0;
+    heth->ErrorCode |= HAL_ETH_ERROR_PARAM;
+    return HAL_ERROR;
   }
+
+  if (heth->gState != HAL_ETH_STATE_STARTED)
+  {
+    return HAL_ERROR;
+  }
+
+  descidx = heth->RxDescList.RxDescIdx;
+  dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descidx];
+  desccntmax = ETH_RX_DESC_CNT - heth->RxDescList.RxBuildDescCnt;
 
   /* Check if descriptor is not owned by DMA */
-  while((READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_OWN) == (uint32_t)RESET) && (descscancnt < (uint32_t)ETH_RX_DESC_CNT))
+  while ((READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_OWN) == (uint32_t)RESET) && (desccnt < desccntmax)
+         && (rxdataready == 0U))
   {
-    descscancnt++;
-
-    /* Check if last descriptor */
-    if(READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_LD) != (uint32_t)RESET)
+    if (READ_BIT(dmarxdesc->DESC3,  ETH_DMARXNDESCWBF_CTXT)  != (uint32_t)RESET)
     {
-      /* Increment the number of descriptors to be passed to the application */
-      appdesccnt += 1U;
-
-      if(appdesccnt == 1U)
+      /* Get timestamp high */
+      heth->RxDescList.TimeStamp.TimeStampHigh = dmarxdesc->DESC1;
+      /* Get timestamp low */
+      heth->RxDescList.TimeStamp.TimeStampLow  = dmarxdesc->DESC0;
+    }
+    if ((READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_FD) != (uint32_t)RESET) || (heth->RxDescList.pRxStart != NULL))
+    {
+      /* Check if first descriptor */
+      if (READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_FD) != (uint32_t)RESET)
       {
-        WRITE_REG(firstappdescidx, descidx);
+        heth->RxDescList.RxDescCnt = 0;
+        heth->RxDescList.RxDataLength = 0;
       }
 
-      /* Increment current rx descriptor index */
-      INCR_RX_DESC_INDEX(descidx, 1U);
-
-      /* Check for Context descriptor */
-      /* Get current descriptor address */
-      dmarxdesc = (ETH_DMADescTypeDef *)dmarxdesclist->RxDesc[descidx];
-
-      if(READ_BIT(dmarxdesc->DESC3,  ETH_DMARXNDESCWBF_OWN)  == (uint32_t)RESET)
+      /* Check if last descriptor */
+      bufflength = heth->Init.RxBuffLen;
+      if (READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_LD) != (uint32_t)RESET)
       {
-        if(READ_BIT(dmarxdesc->DESC3,  ETH_DMARXNDESCWBF_CTXT)  != (uint32_t)RESET)
-        {
-          /* Increment the number of descriptors to be passed to the application */
-          dmarxdesclist->AppContextDesc = 1;
-          /* Increment current rx descriptor index */
-          INCR_RX_DESC_INDEX(descidx, 1U);
-        }
-      }
-      /* Fill information to Rx descriptors list */
-      dmarxdesclist->CurRxDesc = descidx;
-      dmarxdesclist->FirstAppDesc = firstappdescidx;
-      dmarxdesclist->AppDescNbr = appdesccnt;
+        bufflength = READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_PL) - heth->RxDescList.RxDataLength;
 
-      /* Return function status */
-      return 1;
-    }
-    /* Check if first descriptor */
-    else if(READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_FD) != (uint32_t)RESET)
-    {
-      WRITE_REG(firstappdescidx, descidx);
-      /* Increment the number of descriptors to be passed to the application */
-      appdesccnt = 1U;
+        /* Save Last descriptor index */
+        heth->RxDescList.pRxLastRxDesc = dmarxdesc->DESC3;
 
-      /* Increment current rx descriptor index */
-      INCR_RX_DESC_INDEX(descidx, 1U);
-      /* Get current descriptor address */
-      dmarxdesc = (ETH_DMADescTypeDef *)dmarxdesclist->RxDesc[descidx];
-    }
-    /* It should be an intermediate descriptor */
-    else
-    {
-      /* Increment the number of descriptors to be passed to the application */
-      appdesccnt += 1U;
-
-      /* Increment current rx descriptor index */
-      INCR_RX_DESC_INDEX(descidx, 1U);
-      /* Get current descriptor address */
-      dmarxdesc = (ETH_DMADescTypeDef *)dmarxdesclist->RxDesc[descidx];
-    }
-  }
-
-  /* Build Descriptors if an incomplete Packet is received */
-  if(appdesccnt > 0U)
-  {
-    dmarxdesclist->CurRxDesc = descidx;
-    dmarxdesclist->FirstAppDesc = firstappdescidx;
-    descidx = firstappdescidx;
-    dmarxdesc = (ETH_DMADescTypeDef *)dmarxdesclist->RxDesc[descidx];
-
-    for(descscancnt = 0; descscancnt < appdesccnt; descscancnt++)
-    {
-      WRITE_REG(dmarxdesc->DESC0, dmarxdesc->BackupAddr0);
-      WRITE_REG(dmarxdesc->DESC3, ETH_DMARXNDESCRF_BUF1V);
-
-      if (READ_REG(dmarxdesc->BackupAddr1) != ((uint32_t)RESET))
-      {
-        WRITE_REG(dmarxdesc->DESC2, dmarxdesc->BackupAddr1);
-        SET_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCRF_BUF2V);
+        /* Packet ready */
+        rxdataready = 1;
       }
 
-      SET_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCRF_OWN);
+      /* Link data */
+#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
+      /*Call registered Link callback*/
+      heth->rxLinkCallback(&heth->RxDescList.pRxStart, &heth->RxDescList.pRxEnd,
+                           (uint8_t *)dmarxdesc->BackupAddr0, bufflength);
+#else
+      /* Link callback */
+      HAL_ETH_RxLinkCallback(&heth->RxDescList.pRxStart, &heth->RxDescList.pRxEnd,
+                             (uint8_t *)dmarxdesc->BackupAddr0, (uint16_t) bufflength);
+#endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
+      heth->RxDescList.RxDescCnt++;
+      heth->RxDescList.RxDataLength += bufflength;
 
-      if(dmarxdesclist->ItMode != ((uint32_t)RESET))
-      {
-        SET_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCRF_IOC);
-      }
-      if(descscancnt < (appdesccnt - 1U))
-      {
-        /* Increment rx descriptor index */
-        INCR_RX_DESC_INDEX(descidx, 1U);
-        /* Get descriptor address */
-        dmarxdesc = (ETH_DMADescTypeDef *)dmarxdesclist->RxDesc[descidx];
-      }
+      /* Clear buffer pointer */
+      dmarxdesc->BackupAddr0 = 0;
     }
 
-    /* Set the Tail pointer address to the last rx descriptor hold by the app */
-    WRITE_REG(heth->Instance->DMACRDTPR, (uint32_t)dmarxdesc);
-  }
-
-  /* Fill information to Rx descriptors list: No received Packet */
-  dmarxdesclist->AppDescNbr = 0U;
-
-  return 0;
-}
-
-/**
-  * @brief  This function gets the buffer address of last received Packet.
-  * @note   Please insure to allocate the RxBuffer structure before calling this function
-  *         how to use example:
-  *           HAL_ETH_GetRxDataLength(heth, &Length);
-  *           BuffersNbr = (Length / heth->Init.RxBuffLen) + 1;
-  *           RxBuffer = (ETH_BufferTypeDef *)malloc(BuffersNbr * sizeof(ETH_BufferTypeDef));
-  *           HAL_ETH_GetRxDataBuffer(heth, RxBuffer);
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @param  RxBuffer: Pointer to a ETH_BufferTypeDef structure
-  * @retval HAL status
-  */
-HAL_StatusTypeDef HAL_ETH_GetRxDataBuffer(ETH_HandleTypeDef *heth, ETH_BufferTypeDef *RxBuffer)
-{
-  ETH_RxDescListTypeDef *dmarxdesclist = &heth->RxDescList;
-  uint32_t descidx = dmarxdesclist->FirstAppDesc;
-  uint32_t index, accumulatedlen = 0, lastdesclen;
-  __IO const ETH_DMADescTypeDef *dmarxdesc = (ETH_DMADescTypeDef *)dmarxdesclist->RxDesc[descidx];
-  ETH_BufferTypeDef *rxbuff = RxBuffer;
-
-  if(rxbuff == NULL)
-  {
-    heth->ErrorCode = HAL_ETH_ERROR_PARAM;
-    return HAL_ERROR;
-  }
-
-  if(dmarxdesclist->AppDescNbr == 0U)
-  {
-    if(HAL_ETH_IsRxDataAvailable(heth) == 0U)
-    {
-      /* No data to be transferred to the application */
-      return HAL_ERROR;
-    }
-    else
-    {
-      descidx = dmarxdesclist->FirstAppDesc;
-      dmarxdesc = (ETH_DMADescTypeDef *)dmarxdesclist->RxDesc[descidx];
-    }
-  }
-
-  /* Get intermediate descriptors buffers: in case of the Packet is split into multi descriptors */
-  for(index = 0; index < (dmarxdesclist->AppDescNbr - 1U); index++)
-  {
-    /* Get Address and length of the first buffer address */
-    rxbuff->buffer = (uint8_t *) dmarxdesc->BackupAddr0;
-    rxbuff->len =  heth->Init.RxBuffLen;
-
-    /* Check if the second buffer address of this descriptor is valid */
-    if(dmarxdesc->BackupAddr1 != 0U)
-    {
-      /* Point to next buffer */
-      rxbuff = rxbuff->next;
-      /* Get Address and length of the second buffer address */
-      rxbuff->buffer = (uint8_t *) dmarxdesc->BackupAddr1;
-      rxbuff->len =  heth->Init.RxBuffLen;
-    }
-    else
-    {
-      /* Nothing to do here */
-    }
-
-    /* get total length until this descriptor */
-    accumulatedlen = READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_PL);
-
-    /* Increment to next descriptor */
+    /* Increment current rx descriptor index */
     INCR_RX_DESC_INDEX(descidx, 1U);
-    dmarxdesc = (ETH_DMADescTypeDef *)dmarxdesclist->RxDesc[descidx];
-
-    /* Point to next buffer */
-    rxbuff = rxbuff->next;
+    /* Get current descriptor address */
+    dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descidx];
+    desccnt++;
   }
 
-  /* last descriptor data length */
-  lastdesclen = READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_PL) - accumulatedlen;
-
-  /* Get Address of the first buffer address */
-  rxbuff->buffer = (uint8_t *) dmarxdesc->BackupAddr0;
-
-  /* data is in only one buffer */
-  if(lastdesclen <= heth->Init.RxBuffLen)
+  heth->RxDescList.RxBuildDescCnt += desccnt;
+  if ((heth->RxDescList.RxBuildDescCnt) != 0U)
   {
-    rxbuff->len = lastdesclen;
-  }
-  /* data is in two buffers */
-  else if(dmarxdesc->BackupAddr1 != 0U)
-  {
-    /* Get the Length of the first buffer address */
-    rxbuff->len = heth->Init.RxBuffLen;
-    /* Point to next buffer */
-    rxbuff = rxbuff->next;
-    /* Get the Address the Length of the second buffer address */
-    rxbuff->buffer = (uint8_t *) dmarxdesc->BackupAddr1;
-    rxbuff->len =  lastdesclen - (heth->Init.RxBuffLen);
-  }
-  else /* Buffer 2 not valid*/
-  {
-    return HAL_ERROR;
+    /* Update Descriptors */
+    ETH_UpdateDescriptor(heth);
   }
 
-  return HAL_OK;
+  heth->RxDescList.RxDescIdx = descidx;
+
+  if (rxdataready == 1U)
+  {
+    /* Return received packet */
+    *pAppBuff = heth->RxDescList.pRxStart;
+    /* Reset first element */
+    heth->RxDescList.pRxStart = NULL;
+
+    return HAL_OK;
+  }
+
+  /* Packet not ready */
+  return HAL_ERROR;
 }
 
 /**
-  * @brief  This function gets the length of last received Packet.
+  * @brief  This function gives back Rx Desc of the last received Packet
+  *         to the DMA, so ETH DMA will be able to use these descriptors
+  *         to receive next Packets.
   * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
-  * @param  Length: parameter to hold Rx packet length
-  * @retval HAL Status
-  */
-HAL_StatusTypeDef HAL_ETH_GetRxDataLength(ETH_HandleTypeDef *heth, uint32_t *Length)
-{
-  ETH_RxDescListTypeDef *dmarxdesclist = &heth->RxDescList;
-  uint32_t descidx = dmarxdesclist->FirstAppDesc;
-  __IO const ETH_DMADescTypeDef *dmarxdesc;
-
-  if(dmarxdesclist->AppDescNbr == 0U)
-  {
-    if(HAL_ETH_IsRxDataAvailable(heth) == 0U)
-    {
-      /* No data to be transferred to the application */
-      return HAL_ERROR;
-    }
-  }
-
-  /* Get index of last descriptor */
-  INCR_RX_DESC_INDEX(descidx, (dmarxdesclist->AppDescNbr - 1U));
-  /* Point to last descriptor */
-  dmarxdesc = (ETH_DMADescTypeDef *)dmarxdesclist->RxDesc[descidx];
-
-  *Length = READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_PL);
-
-  return HAL_OK;
-}
-
-/**
-  * @brief  Get the Rx data info (Packet type, VLAN tag, Filters status, ...)
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @param  RxPacketInfo: parameter to hold info of received buffer
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETH_GetRxDataInfo(ETH_HandleTypeDef *heth, ETH_RxPacketInfo *RxPacketInfo)
+static void ETH_UpdateDescriptor(ETH_HandleTypeDef *heth)
 {
-  ETH_RxDescListTypeDef *dmarxdesclist = &heth->RxDescList;
-  uint32_t descidx = dmarxdesclist->FirstAppDesc;
-  __IO const ETH_DMADescTypeDef *dmarxdesc;
+  uint32_t descidx;
+  uint32_t desccount;
+  ETH_DMADescTypeDef *dmarxdesc;
+  uint8_t *buff = NULL;
+  uint8_t allocStatus = 1U;
 
-  if(dmarxdesclist->AppDescNbr == 0U)
+  descidx = heth->RxDescList.RxBuildDescIdx;
+  dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descidx];
+  desccount = heth->RxDescList.RxBuildDescCnt;
+
+  while ((desccount > 0U) && (allocStatus != 0U))
   {
-    if(HAL_ETH_IsRxDataAvailable(heth) == 0U)
+    /* Check if a buffer's attached the descriptor */
+    if (READ_REG(dmarxdesc->BackupAddr0) == 0U)
     {
-      /* No data to be transferred to the application */
-      return HAL_ERROR;
-    }
-  }
-
-  /* Get index of last descriptor */
-  INCR_RX_DESC_INDEX(descidx, ((dmarxdesclist->AppDescNbr) - 1U));
-  /* Point to last descriptor */
-  dmarxdesc = (ETH_DMADescTypeDef *)dmarxdesclist->RxDesc[descidx];
-
-  if((dmarxdesc->DESC3 & ETH_DMARXNDESCWBF_ES) != (uint32_t)RESET)
-  {
-    RxPacketInfo->ErrorCode = READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_ERRORS_MASK);
-  }
-  else
-  {
-    if(READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_RS0V) != 0U)
-    {
-
-      if(READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_LT) == ETH_DMARXNDESCWBF_LT_DVLAN)
+      /* Get a new buffer. */
+#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
+      /*Call registered Allocate callback*/
+      heth->rxAllocateCallback(&buff);
+#else
+      /* Allocate callback */
+      HAL_ETH_RxAllocateCallback(&buff);
+#endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
+      if (buff == NULL)
       {
-        RxPacketInfo->VlanTag = READ_BIT(dmarxdesc->DESC0, ETH_DMARXNDESCWBF_OVT);
-        RxPacketInfo->InnerVlanTag = READ_BIT(dmarxdesc->DESC0, ETH_DMARXNDESCWBF_IVT) >> 16;
+        allocStatus = 0U;
       }
       else
       {
-        RxPacketInfo->VlanTag = READ_BIT(dmarxdesc->DESC0, ETH_DMARXNDESCWBF_OVT);
+        WRITE_REG(dmarxdesc->BackupAddr0, (uint32_t)buff);
+        WRITE_REG(dmarxdesc->DESC0, (uint32_t)buff);
       }
     }
 
-    if(READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_RS1V) != 0U)
+    if (allocStatus != 0U)
     {
-      /* Get Payload type */
-      RxPacketInfo->PayloadType =READ_BIT( dmarxdesc->DESC1, ETH_DMARXNDESCWBF_PT);
-      /* Get Header type */
-      RxPacketInfo->HeaderType = READ_BIT(dmarxdesc->DESC1, (ETH_DMARXNDESCWBF_IPV4 | ETH_DMARXNDESCWBF_IPV6));
-      /* Get Checksum status */
-      RxPacketInfo->Checksum = READ_BIT(dmarxdesc->DESC1, (ETH_DMARXNDESCWBF_IPCE | ETH_DMARXNDESCWBF_IPCB | ETH_DMARXNDESCWBF_IPHE));
-    }
+      /* Ensure rest of descriptor is written to RAM before the OWN bit */
+      __DMB();
 
-    if(READ_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCWBF_RS2V) != 0U)
-    {
-      RxPacketInfo->MacFilterStatus = READ_BIT(dmarxdesc->DESC2, (ETH_DMARXNDESCWBF_HF | ETH_DMARXNDESCWBF_DAF | ETH_DMARXNDESCWBF_SAF | ETH_DMARXNDESCWBF_VF));
-      RxPacketInfo->L3FilterStatus = READ_BIT(dmarxdesc->DESC2,  (ETH_DMARXNDESCWBF_L3FM | ETH_DMARXNDESCWBF_L3L4FM));
-      RxPacketInfo->L4FilterStatus = READ_BIT(dmarxdesc->DESC2, (ETH_DMARXNDESCWBF_L4FM | ETH_DMARXNDESCWBF_L3L4FM));
+      if (heth->RxDescList.ItMode != 0U)
+      {
+        WRITE_REG(dmarxdesc->DESC3, ETH_DMARXNDESCRF_OWN | ETH_DMARXNDESCRF_BUF1V | ETH_DMARXNDESCRF_IOC);
+      }
+      else
+      {
+        WRITE_REG(dmarxdesc->DESC3, ETH_DMARXNDESCRF_OWN | ETH_DMARXNDESCRF_BUF1V);
+      }
+
+      /* Increment current rx descriptor index */
+      INCR_RX_DESC_INDEX(descidx, 1U);
+      /* Get current descriptor address */
+      dmarxdesc = (ETH_DMADescTypeDef *)heth->RxDescList.RxDesc[descidx];
+      desccount--;
     }
   }
 
-  /* Get the segment count */
-  WRITE_REG(RxPacketInfo->SegmentCnt, dmarxdesclist->AppDescNbr);
+  if (heth->RxDescList.RxBuildDescCnt != desccount)
+  {
+    /* Set the Tail pointer address */
+    WRITE_REG(heth->Instance->DMACRDTPR, 0);
+
+    heth->RxDescList.RxBuildDescIdx = descidx;
+    heth->RxDescList.RxBuildDescCnt = desccount;
+  }
+}
+
+/**
+  * @brief  Register the Rx alloc callback.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  rxAllocateCallback: pointer to function to alloc buffer
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_RegisterRxAllocateCallback(ETH_HandleTypeDef *heth,
+                                                     pETH_rxAllocateCallbackTypeDef rxAllocateCallback)
+{
+  if (rxAllocateCallback == NULL)
+  {
+    /* No buffer to save */
+    return HAL_ERROR;
+  }
+
+  /* Set function to allocate buffer */
+  heth->rxAllocateCallback = rxAllocateCallback;
 
   return HAL_OK;
 }
 
 /**
-* @brief  This function gives back Rx Desc of the last received Packet
-*         to the DMA, so ETH DMA will be able to use these descriptors
-*         to receive next Packets.
-*         It should be called after processing the received Packet.
-* @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-*         the configuration information for ETHERNET module
-* @retval HAL status.
-*/
-HAL_StatusTypeDef HAL_ETH_BuildRxDescriptors(ETH_HandleTypeDef *heth)
+  * @brief  Unregister the Rx alloc callback.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_UnRegisterRxAllocateCallback(ETH_HandleTypeDef *heth)
 {
-  ETH_RxDescListTypeDef *dmarxdesclist = &heth->RxDescList;
-  uint32_t descindex = dmarxdesclist->FirstAppDesc;
-  __IO ETH_DMADescTypeDef *dmarxdesc = (ETH_DMADescTypeDef *)dmarxdesclist->RxDesc[descindex];
-  uint32_t totalappdescnbr = dmarxdesclist->AppDescNbr;
-  uint32_t descscan;
-
-  if(dmarxdesclist->AppDescNbr == 0U)
-  {
-    /* No Rx descriptors to build */
-    return HAL_ERROR;
-  }
-
-  if(dmarxdesclist->AppContextDesc != 0U)
-  {
-    /* A context descriptor is available */
-    totalappdescnbr += 1U;
-  }
-
-  for(descscan =0; descscan < totalappdescnbr; descscan++)
-  {
-    WRITE_REG(dmarxdesc->DESC0, dmarxdesc->BackupAddr0);
-    WRITE_REG(dmarxdesc->DESC3, ETH_DMARXNDESCRF_BUF1V);
-
-    if (READ_REG(dmarxdesc->BackupAddr1) != 0U)
-    {
-      WRITE_REG(dmarxdesc->DESC2, dmarxdesc->BackupAddr1);
-      SET_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCRF_BUF2V);
-    }
-
-    SET_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCRF_OWN);
-
-    if(dmarxdesclist->ItMode != 0U)
-    {
-      SET_BIT(dmarxdesc->DESC3, ETH_DMARXNDESCRF_IOC);
-    }
-
-    if(descscan < (totalappdescnbr - 1U))
-    {
-      /* Increment rx descriptor index */
-      INCR_RX_DESC_INDEX(descindex, 1U);
-      /* Get descriptor address */
-      dmarxdesc = (ETH_DMADescTypeDef *)dmarxdesclist->RxDesc[descindex];
-    }
-  }
-
-  /* Set the Tail pointer address to the last rx descriptor hold by the app */
-  WRITE_REG(heth->Instance->DMACRDTPR, (uint32_t)dmarxdesc);
-
-  /* reset the Application desc number */
-  WRITE_REG(dmarxdesclist->AppDescNbr, 0);
-
-  /*  reset the application context descriptor */
-  WRITE_REG(heth->RxDescList.AppContextDesc, 0);
+  /* Set function to allocate buffer */
+  heth->rxAllocateCallback = HAL_ETH_RxAllocateCallback;
 
   return HAL_OK;
 }
 
+/**
+  * @brief  Rx Allocate callback.
+  * @param  buff: pointer to allocated buffer
+  * @retval None
+  */
+__weak void HAL_ETH_RxAllocateCallback(uint8_t **buff)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(buff);
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_ETH_RxAllocateCallback could be implemented in the user file
+  */
+}
+
+/**
+  * @brief  Rx Link callback.
+  * @param  pStart: pointer to packet start
+  * @param  pStart: pointer to packet end
+  * @param  buff: pointer to received data
+  * @param  Length: received data length
+  * @retval None
+  */
+__weak void HAL_ETH_RxLinkCallback(void **pStart, void **pEnd, uint8_t *buff, uint16_t Length)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(pStart);
+  UNUSED(pEnd);
+  UNUSED(buff);
+  UNUSED(Length);
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_ETH_RxLinkCallback could be implemented in the user file
+  */
+}
+
+/**
+  * @brief  Set the Rx link data function.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  rxLinkCallback: pointer to function to link data
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_RegisterRxLinkCallback(ETH_HandleTypeDef *heth, pETH_rxLinkCallbackTypeDef rxLinkCallback)
+{
+  if (rxLinkCallback == NULL)
+  {
+    /* No buffer to save */
+    return HAL_ERROR;
+  }
+
+  /* Set function to link data */
+  heth->rxLinkCallback = rxLinkCallback;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Unregister the Rx link callback.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_UnRegisterRxLinkCallback(ETH_HandleTypeDef *heth)
+{
+  /* Set function to allocate buffer */
+  heth->rxLinkCallback = HAL_ETH_RxLinkCallback;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get the error state of the last received packet.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  pErrorCode: pointer to uint32_t to hold the error code
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_GetRxDataErrorCode(ETH_HandleTypeDef *heth, uint32_t *pErrorCode)
+{
+  /* Get error bits. */
+  *pErrorCode = READ_BIT(heth->RxDescList.pRxLastRxDesc, ETH_DMARXNDESCWBF_ERRORS_MASK);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set the Tx free function.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  txFreeCallback: pointer to function to release the packet
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_RegisterTxFreeCallback(ETH_HandleTypeDef *heth, pETH_txFreeCallbackTypeDef txFreeCallback)
+{
+  if (txFreeCallback == NULL)
+  {
+    /* No buffer to save */
+    return HAL_ERROR;
+  }
+
+  /* Set function to free transmmitted packet */
+  heth->txFreeCallback = txFreeCallback;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Unregister the Tx free callback.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_UnRegisterTxFreeCallback(ETH_HandleTypeDef *heth)
+{
+  /* Set function to allocate buffer */
+  heth->txFreeCallback = HAL_ETH_TxFreeCallback;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Tx Free callback.
+  * @param  buff: pointer to buffer to free
+  * @retval None
+  */
+__weak void HAL_ETH_TxFreeCallback(uint32_t *buff)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(buff);
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_ETH_TxFreeCallback could be implemented in the user file
+  */
+}
+
+/**
+  * @brief  Release transmitted Tx packets.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_ReleaseTxPacket(ETH_HandleTypeDef *heth)
+{
+  ETH_TxDescListTypeDef *dmatxdesclist = &heth->TxDescList;
+  uint32_t numOfBuf =  dmatxdesclist->BuffersInUse;
+  uint32_t idx =       dmatxdesclist->releaseIndex;
+  uint8_t pktTxStatus = 1U;
+  uint8_t pktInUse;
+#ifdef HAL_ETH_USE_PTP
+  ETH_TimeStampTypeDef *timestamp = &heth->TxTimestamp;
+#endif /* HAL_ETH_USE_PTP */
+
+  /* Loop through buffers in use.  */
+  while ((numOfBuf != 0U) && (pktTxStatus != 0U))
+  {
+    pktInUse = 1U;
+    numOfBuf--;
+    /* If no packet, just examine the next packet.  */
+    if (dmatxdesclist->PacketAddress[idx] == NULL)
+    {
+      /* No packet in use, skip to next.  */
+      idx = (idx + 1U) & (ETH_TX_DESC_CNT - 1U);
+      pktInUse = 0U;
+    }
+
+    if (pktInUse != 0U)
+    {
+      /* Determine if the packet has been transmitted.  */
+      if ((heth->Init.TxDesc[idx].DESC3 & ETH_DMATXNDESCRF_OWN) == 0U)
+      {
+#ifdef HAL_ETH_USE_PTP
+        /* Disable Ptp transmission */
+        CLEAR_BIT(heth->Init.TxDesc[idx].DESC3, ((uint32_t)0x40000000U));
+
+        /* Get timestamp low */
+        timestamp->TimeStampLow = heth->Init.TxDesc[idx].DESC0;
+        /* Get timestamp high */
+        timestamp->TimeStampHigh = heth->Init.TxDesc[idx].DESC1;
+#endif /* HAL_ETH_USE_PTP */
+
+#if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
+        /*Call registered callbacks*/
+#ifdef HAL_ETH_USE_PTP
+        /* Handle Ptp  */
+        heth->txPtpCallback(dmatxdesclist->PacketAddress[idx], timestamp);
+#endif  /* HAL_ETH_USE_PTP */
+        /* Release the packet.  */
+        heth->txFreeCallback(dmatxdesclist->PacketAddress[idx]);
+#else
+        /* Call callbacks */
+#ifdef HAL_ETH_USE_PTP
+        /* Handle Ptp  */
+        HAL_ETH_TxPtpCallback(dmatxdesclist->PacketAddress[idx], timestamp);
+#endif  /* HAL_ETH_USE_PTP */
+        /* Release the packet.  */
+        HAL_ETH_TxFreeCallback(dmatxdesclist->PacketAddress[idx]);
+#endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
+
+        /* Clear the entry in the in-use array.  */
+        dmatxdesclist->PacketAddress[idx] = NULL;
+
+        /* Update the transmit relesae index and number of buffers in use.  */
+        idx = (idx + 1U) & (ETH_TX_DESC_CNT - 1U);
+        dmatxdesclist->BuffersInUse = numOfBuf;
+        dmatxdesclist->releaseIndex = idx;
+      }
+      else
+      {
+        /* Get out of the loop!  */
+        pktTxStatus = 0U;
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+#ifdef HAL_ETH_USE_PTP
+/**
+  * @brief  Set the Ethernet PTP configuration.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  ptpconfig: pointer to a ETH_PTP_ConfigTypeDef structure that contains
+  *         the configuration information for PTP
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_PTP_SetConfig(ETH_HandleTypeDef *heth, ETH_PTP_ConfigTypeDef *ptpconfig)
+{
+  uint32_t tmpTSCR;
+  ETH_TimeTypeDef time;
+
+  if (ptpconfig == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  tmpTSCR = ptpconfig->Timestamp |
+            ((uint32_t)ptpconfig->TimestampUpdate << ETH_MACTSCR_TSUPDT_Pos) |
+            ((uint32_t)ptpconfig->TimestampAll << ETH_MACTSCR_TSENALL_Pos) |
+            ((uint32_t)ptpconfig->TimestampRolloverMode << ETH_MACTSCR_TSCTRLSSR_Pos) |
+            ((uint32_t)ptpconfig->TimestampV2 << ETH_MACTSCR_TSVER2ENA_Pos) |
+            ((uint32_t)ptpconfig->TimestampEthernet << ETH_MACTSCR_TSIPENA_Pos) |
+            ((uint32_t)ptpconfig->TimestampIPv6 << ETH_MACTSCR_TSIPV6ENA_Pos) |
+            ((uint32_t)ptpconfig->TimestampIPv4 << ETH_MACTSCR_TSIPV4ENA_Pos) |
+            ((uint32_t)ptpconfig->TimestampEvent << ETH_MACTSCR_TSEVNTENA_Pos) |
+            ((uint32_t)ptpconfig->TimestampMaster << ETH_MACTSCR_TSMSTRENA_Pos) |
+            ((uint32_t)ptpconfig->TimestampSnapshots << ETH_MACTSCR_SNAPTYPSEL_Pos) |
+            ((uint32_t)ptpconfig->TimestampFilter << ETH_MACTSCR_TSENMACADDR_Pos) |
+            ((uint32_t)ptpconfig->TimestampChecksumCorrection << ETH_MACTSCR_CSC_Pos) |
+            ((uint32_t)ptpconfig->TimestampStatusMode << ETH_MACTSCR_TXTSSTSM_Pos);
+
+  /* Write to MACTSCR */
+  MODIFY_REG(heth->Instance->MACTSCR, ETH_MACTSCR_MASK, tmpTSCR);
+
+  /* Enable Timestamp */
+  SET_BIT(heth->Instance->MACTSCR, ETH_MACTSCR_TSENA);
+  WRITE_REG(heth->Instance->MACSSIR, ptpconfig->TimestampSubsecondInc);
+  WRITE_REG(heth->Instance->MACTSAR, ptpconfig->TimestampAddend);
+
+  /* Enable Timestamp */
+  if (ptpconfig->TimestampAddendUpdate == ENABLE)
+  {
+    SET_BIT(heth->Instance->MACTSCR, ETH_MACTSCR_TSADDREG);
+    while ((heth->Instance->MACTSCR & ETH_MACTSCR_TSADDREG) != 0) {}
+  }
+
+  /* Enable Update mode */
+  if (ptpconfig->TimestampUpdateMode == ENABLE)
+  {
+    SET_BIT(heth->Instance->MACTSCR, ETH_MACTSCR_TSCFUPDT);
+  }
+
+  /* Initialize Time */
+  time.Seconds = 0;
+  time.NanoSeconds = 0;
+  HAL_ETH_PTP_SetTime(heth, &time);
+
+  /* Ptp Init */
+  SET_BIT(heth->Instance->MACTSCR, ETH_MACTSCR_TSINIT);
+
+  /* Set PTP Configuration done */
+  heth->IsPtpConfigured = HAL_ETH_PTP_CONFIGURATED;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Get the Ethernet PTP configuration.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  ptpconfig: pointer to a ETH_PTP_ConfigTypeDef structure that contains
+  *         the configuration information for PTP
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_PTP_GetConfig(ETH_HandleTypeDef *heth, ETH_PTP_ConfigTypeDef *ptpconfig)
+{
+  if (ptpconfig == NULL)
+  {
+    return HAL_ERROR;
+  }
+  ptpconfig->Timestamp = READ_BIT(heth->Instance->MACTSCR, ETH_MACTSCR_TSENA);
+  ptpconfig->TimestampUpdate = ((READ_BIT(heth->Instance->MACTSCR,
+                                          ETH_MACTSCR_TSCFUPDT) >> ETH_MACTSCR_TSUPDT_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampAll = ((READ_BIT(heth->Instance->MACTSCR,
+                                       ETH_MACTSCR_TSENALL) >> ETH_MACTSCR_TSENALL_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampRolloverMode = ((READ_BIT(heth->Instance->MACTSCR,
+                                                ETH_MACTSCR_TSCTRLSSR) >> ETH_MACTSCR_TSCTRLSSR_Pos) > 0U)
+                                     ? ENABLE : DISABLE;
+  ptpconfig->TimestampV2 = ((READ_BIT(heth->Instance->MACTSCR,
+                                      ETH_MACTSCR_TSVER2ENA) >> ETH_MACTSCR_TSVER2ENA_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampEthernet = ((READ_BIT(heth->Instance->MACTSCR,
+                                            ETH_MACTSCR_TSIPENA) >> ETH_MACTSCR_TSIPENA_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampIPv6 = ((READ_BIT(heth->Instance->MACTSCR,
+                                        ETH_MACTSCR_TSIPV6ENA) >> ETH_MACTSCR_TSIPV6ENA_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampIPv4 = ((READ_BIT(heth->Instance->MACTSCR,
+                                        ETH_MACTSCR_TSIPV4ENA) >> ETH_MACTSCR_TSIPV4ENA_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampEvent = ((READ_BIT(heth->Instance->MACTSCR,
+                                         ETH_MACTSCR_TSEVNTENA) >> ETH_MACTSCR_TSEVNTENA_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampMaster = ((READ_BIT(heth->Instance->MACTSCR,
+                                          ETH_MACTSCR_TSMSTRENA) >> ETH_MACTSCR_TSMSTRENA_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampSnapshots = ((READ_BIT(heth->Instance->MACTSCR,
+                                             ETH_MACTSCR_SNAPTYPSEL) >> ETH_MACTSCR_SNAPTYPSEL_Pos) > 0U)
+                                  ? ENABLE : DISABLE;
+  ptpconfig->TimestampFilter = ((READ_BIT(heth->Instance->MACTSCR,
+                                          ETH_MACTSCR_TSENMACADDR) >> ETH_MACTSCR_TSENMACADDR_Pos) > 0U)
+                               ? ENABLE : DISABLE;
+  ptpconfig->TimestampChecksumCorrection = ((READ_BIT(heth->Instance->MACTSCR,
+                                                      ETH_MACTSCR_CSC) >> ETH_MACTSCR_CSC_Pos) > 0U) ? ENABLE : DISABLE;
+  ptpconfig->TimestampStatusMode = ((READ_BIT(heth->Instance->MACTSCR,
+                                              ETH_MACTSCR_TXTSSTSM) >> ETH_MACTSCR_TXTSSTSM_Pos) > 0U)
+                                   ? ENABLE : DISABLE;
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Set Seconds and Nanoseconds for the Ethernet PTP registers.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  heth: pointer to a ETH_TimeTypeDef structure that contains
+  *         time to set
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_PTP_SetTime(ETH_HandleTypeDef *heth, ETH_TimeTypeDef *time)
+{
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  {
+    /* Set Seconds */
+    heth->Instance->MACSTSUR = time->Seconds;
+
+    /* Set NanoSeconds */
+    heth->Instance->MACSTNUR = time->NanoSeconds;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Get Seconds and Nanoseconds for the Ethernet PTP registers.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  heth: pointer to a ETH_TimeTypeDef structure that contains
+  *         time to get
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_PTP_GetTime(ETH_HandleTypeDef *heth, ETH_TimeTypeDef *time)
+{
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  {
+    /* Get Seconds */
+    time->Seconds = heth->Instance->MACSTSUR;
+
+    /* Get NanoSeconds */
+    time->NanoSeconds = heth->Instance->MACSTNUR;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Update time for the Ethernet PTP registers.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  timeupdate: pointer to a ETH_TIMEUPDATETypeDef structure that contains
+  *         the time update information
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_PTP_AddTimeOffset(ETH_HandleTypeDef *heth, ETH_PtpUpdateTypeDef ptpoffsettype,
+                                            ETH_TimeTypeDef *timeoffset)
+{
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  {
+    if (ptpoffsettype ==  HAL_ETH_PTP_NEGATIVE_UPDATE)
+    {
+      /* Set Seconds update */
+      heth->Instance->MACSTSUR = ETH_MACSTSUR_VALUE - timeoffset->Seconds + 1U;
+
+      if (READ_BIT(heth->Instance->MACTSCR, ETH_MACTSCR_TSCTRLSSR) == ETH_MACTSCR_TSCTRLSSR)
+      {
+        /* Set nanoSeconds update */
+        heth->Instance->MACSTNUR = ETH_MACSTNUR_VALUE - timeoffset->NanoSeconds;
+      }
+      else
+      {
+        /* Set nanoSeconds update */
+        heth->Instance->MACSTNUR = ETH_MACSTSUR_VALUE - timeoffset->NanoSeconds + 1U;
+      }
+    }
+    else
+    {
+      /* Set Seconds update */
+      heth->Instance->MACSTSUR = timeoffset->Seconds;
+      /* Set nanoSeconds update */
+      heth->Instance->MACSTNUR = timeoffset->NanoSeconds;
+    }
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Insert Timestamp in transmission.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  txtimestampconf: Enable or Disable timestamp in transmission
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_PTP_InsertTxTimestamp(ETH_HandleTypeDef *heth)
+{
+  ETH_TxDescListTypeDef *dmatxdesclist = &heth->TxDescList;
+  uint32_t descidx = dmatxdesclist->CurTxDesc;
+  ETH_DMADescTypeDef *dmatxdesc = (ETH_DMADescTypeDef *)dmatxdesclist->TxDesc[descidx];
+
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  {
+    /* Enable Time Stamp transmission */
+    SET_BIT(dmatxdesc->DESC2, ETH_DMATXNDESCRF_TTSE);
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Get transmission timestamp.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  timestamp: pointer to ETH_TIMESTAMPTypeDef structure that contains
+  *         transmission timestamp
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_PTP_GetTxTimestamp(ETH_HandleTypeDef *heth, ETH_TimeStampTypeDef *timestamp)
+{
+  ETH_TxDescListTypeDef *dmatxdesclist = &heth->TxDescList;
+  uint32_t idx =       dmatxdesclist->releaseIndex;
+  ETH_DMADescTypeDef *dmatxdesc = (ETH_DMADescTypeDef *)dmatxdesclist->TxDesc[idx];
+
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  {
+    /* Get timestamp low */
+    timestamp->TimeStampLow = dmatxdesc->DESC0;
+    /* Get timestamp high */
+    timestamp->TimeStampHigh = dmatxdesc->DESC1;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Get receive timestamp.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  timestamp: pointer to ETH_TIMESTAMPTypeDef structure that contains
+  *         receive timestamp
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_PTP_GetRxTimestamp(ETH_HandleTypeDef *heth, ETH_TimeStampTypeDef *timestamp)
+{
+  if (heth->IsPtpConfigured == HAL_ETH_PTP_CONFIGURATED)
+  {
+    /* Get timestamp low */
+    timestamp->TimeStampLow = heth->RxDescList.TimeStamp.TimeStampLow;
+    /* Get timestamp high */
+    timestamp->TimeStampHigh = heth->RxDescList.TimeStamp.TimeStampHigh;
+
+    /* Return function status */
+    return HAL_OK;
+  }
+  else
+  {
+    /* Return function status */
+    return HAL_ERROR;
+  }
+}
+
+/**
+  * @brief  Register the Tx Ptp callback.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @param  txPtpCallback: Function to handle Ptp transmission
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_RegisterTxPtpCallback(ETH_HandleTypeDef *heth, pETH_txPtpCallbackTypeDef txPtpCallback)
+{
+  if (txPtpCallback == NULL)
+  {
+    /* No buffer to save */
+    return HAL_ERROR;
+  }
+  /* Set Function to handle Tx Ptp */
+  heth->txPtpCallback = txPtpCallback;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Unregister the Tx Ptp callback.
+  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
+  *         the configuration information for ETHERNET module
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ETH_UnRegisterTxPtpCallback(ETH_HandleTypeDef *heth)
+{
+  /* Set function to allocate buffer */
+  heth->txPtpCallback = HAL_ETH_TxPtpCallback;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Tx Ptp callback.
+  * @param  buff: pointer to application buffer
+  * @retval None
+  */
+__weak void HAL_ETH_TxPtpCallback(uint32_t *buff, ETH_TimeStampTypeDef *timestamp)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(buff);
+  /* NOTE : This function Should not be modified, when the callback is needed,
+  the HAL_ETH_TxPtpCallback could be implemented in the user file
+  */
+}
+#endif  /* HAL_ETH_USE_PTP */
 
 /**
   * @brief  This function handles ETH interrupt request.
@@ -1474,11 +1831,14 @@ HAL_StatusTypeDef HAL_ETH_BuildRxDescriptors(ETH_HandleTypeDef *heth)
   */
 void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
 {
+  uint32_t macirqenable;
   /* Packet received */
   if (__HAL_ETH_DMA_GET_IT(heth, ETH_DMACSR_RI))
   {
-    if(__HAL_ETH_DMA_GET_IT_SOURCE(heth, ETH_DMACIER_RIE))
+    if (__HAL_ETH_DMA_GET_IT_SOURCE(heth, ETH_DMACIER_RIE))
     {
+      /* Clear the Eth DMA Rx IT pending bits */
+      __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMACSR_RI | ETH_DMACSR_NIS);
 
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
       /*Call registered Receive complete callback*/
@@ -1487,35 +1847,32 @@ void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
       /* Receive complete callback */
       HAL_ETH_RxCpltCallback(heth);
 #endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
-
-      /* Clear the Eth DMA Rx IT pending bits */
-      __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMACSR_RI | ETH_DMACSR_NIS);
     }
   }
 
   /* Packet transmitted */
   if (__HAL_ETH_DMA_GET_IT(heth, ETH_DMACSR_TI))
   {
-    if(__HAL_ETH_DMA_GET_IT_SOURCE(heth, ETH_DMACIER_TIE))
+    if (__HAL_ETH_DMA_GET_IT_SOURCE(heth, ETH_DMACIER_TIE))
     {
+      /* Clear the Eth DMA Tx IT pending bits */
+      __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMACSR_TI | ETH_DMACSR_NIS);
+
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
-        /*Call registered Transmit complete callback*/
-        heth->TxCpltCallback(heth);
+      /*Call registered Transmit complete callback*/
+      heth->TxCpltCallback(heth);
 #else
       /* Transfer complete callback */
       HAL_ETH_TxCpltCallback(heth);
 #endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
-
-      /* Clear the Eth DMA Tx IT pending bits */
-      __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMACSR_TI | ETH_DMACSR_NIS);
     }
   }
 
 
   /* ETH DMA Error */
-  if(__HAL_ETH_DMA_GET_IT(heth, ETH_DMACSR_AIS))
+  if (__HAL_ETH_DMA_GET_IT(heth, ETH_DMACSR_AIS))
   {
-    if(__HAL_ETH_DMA_GET_IT_SOURCE(heth, ETH_DMACIER_AIE))
+    if (__HAL_ETH_DMA_GET_IT_SOURCE(heth, ETH_DMACIER_AIE))
     {
       heth->ErrorCode |= HAL_ETH_ERROR_DMA;
 
@@ -1534,45 +1891,49 @@ void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
       else
       {
         /* Get DMA error status  */
-       heth->DMAErrorCode = READ_BIT(heth->Instance->DMACSR, (ETH_DMACSR_CDE | ETH_DMACSR_ETI | ETH_DMACSR_RWT |
-                                                       ETH_DMACSR_RBU | ETH_DMACSR_AIS));
+        heth->DMAErrorCode = READ_BIT(heth->Instance->DMACSR, (ETH_DMACSR_CDE | ETH_DMACSR_ETI | ETH_DMACSR_RWT |
+                                                               ETH_DMACSR_RBU | ETH_DMACSR_AIS));
 
         /* Clear the interrupt summary flag */
         __HAL_ETH_DMA_CLEAR_IT(heth, (ETH_DMACSR_CDE | ETH_DMACSR_ETI | ETH_DMACSR_RWT |
-                                    ETH_DMACSR_RBU | ETH_DMACSR_AIS));
+                                      ETH_DMACSR_RBU | ETH_DMACSR_AIS));
       }
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
-      /* Call registered DMA Error callback*/
-      heth->DMAErrorCallback(heth);
+      /* Call registered Error callback*/
+      heth->ErrorCallback(heth);
 #else
       /* Ethernet DMA Error callback */
-      HAL_ETH_DMAErrorCallback(heth);
+      HAL_ETH_ErrorCallback(heth);
 #endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
 
     }
   }
 
   /* ETH MAC Error IT */
-  if(__HAL_ETH_MAC_GET_IT(heth, (ETH_MACIER_RXSTSIE | ETH_MACIER_TXSTSIE)))
+  macirqenable = heth->Instance->MACIER;
+  if (((macirqenable & ETH_MACIER_RXSTSIE) == ETH_MACIER_RXSTSIE) || \
+      ((macirqenable & ETH_MACIER_TXSTSIE) == ETH_MACIER_TXSTSIE))
   {
+    heth->ErrorCode |= HAL_ETH_ERROR_MAC;
+
     /* Get MAC Rx Tx status and clear Status register pending bit */
     heth->MACErrorCode = READ_REG(heth->Instance->MACRXTXSR);
 
     heth->gState = HAL_ETH_STATE_ERROR;
 
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
-    /* Call registered MAC Error callback*/
-    heth->DMAErrorCallback(heth);
+    /* Call registered Error callback*/
+    heth->ErrorCallback(heth);
 #else
-    /* Ethernet MAC Error callback */
-    HAL_ETH_MACErrorCallback(heth);
+    /* Ethernet Error callback */
+    HAL_ETH_ErrorCallback(heth);
 #endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
 
     heth->MACErrorCode = (uint32_t)(0x0U);
   }
 
   /* ETH PMT IT */
-  if(__HAL_ETH_MAC_GET_IT(heth, ETH_MAC_PMT_IT))
+  if (__HAL_ETH_MAC_GET_IT(heth, ETH_MAC_PMT_IT))
   {
     /* Get MAC Wake-up source and clear the status register pending bit */
     heth->MACWakeUpEvent = READ_BIT(heth->Instance->MACPCSR, (ETH_MACPCSR_RWKPRCVD | ETH_MACPCSR_MGKPRCVD));
@@ -1589,7 +1950,7 @@ void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
   }
 
   /* ETH EEE IT */
-  if(__HAL_ETH_MAC_GET_IT(heth, ETH_MAC_LPI_IT))
+  if (__HAL_ETH_MAC_GET_IT(heth, ETH_MAC_LPI_IT))
   {
     /* Get MAC LPI interrupt source and clear the status register pending bit */
     heth->MACLPIEvent = READ_BIT(heth->Instance->MACPCSR, 0x0000000FU);
@@ -1609,7 +1970,7 @@ void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
   if (HAL_GetCurrentCPUID() == CM7_CPUID)
   {
     /* check ETH WAKEUP exti flag */
-    if(__HAL_ETH_WAKEUP_EXTI_GET_FLAG(ETH_WAKEUP_EXTI_LINE) != (uint32_t)RESET)
+    if (__HAL_ETH_WAKEUP_EXTI_GET_FLAG(ETH_WAKEUP_EXTI_LINE) != (uint32_t)RESET)
     {
       /* Clear ETH WAKEUP Exti pending bit */
       __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG(ETH_WAKEUP_EXTI_LINE);
@@ -1619,13 +1980,13 @@ void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
 #else
       /* ETH WAKEUP callback */
       HAL_ETH_WakeUpCallback(heth);
-#endif
+#endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
     }
   }
   else
   {
     /* check ETH WAKEUP exti flag */
-    if(__HAL_ETH_WAKEUP_EXTID2_GET_FLAG(ETH_WAKEUP_EXTI_LINE) != (uint32_t)RESET)
+    if (__HAL_ETH_WAKEUP_EXTID2_GET_FLAG(ETH_WAKEUP_EXTI_LINE) != (uint32_t)RESET)
     {
       /* Clear ETH WAKEUP Exti pending bit */
       __HAL_ETH_WAKEUP_EXTID2_CLEAR_FLAG(ETH_WAKEUP_EXTI_LINE);
@@ -1635,24 +1996,24 @@ void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
 #else
       /* ETH WAKEUP callback */
       HAL_ETH_WakeUpCallback(heth);
-#endif
+#endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
     }
   }
-#else
+#else /* USE_HAL_ETH_REGISTER_CALLBACKS */
   /* check ETH WAKEUP exti flag */
-  if(__HAL_ETH_WAKEUP_EXTI_GET_FLAG(ETH_WAKEUP_EXTI_LINE) != (uint32_t)RESET)
+  if (__HAL_ETH_WAKEUP_EXTI_GET_FLAG(ETH_WAKEUP_EXTI_LINE) != (uint32_t)RESET)
   {
     /* Clear ETH WAKEUP Exti pending bit */
     __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG(ETH_WAKEUP_EXTI_LINE);
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
-      /* Call registered WakeUp callback*/
-      heth->WakeUpCallback(heth);
+    /* Call registered WakeUp callback*/
+    heth->WakeUpCallback(heth);
 #else
-      /* ETH WAKEUP callback */
-      HAL_ETH_WakeUpCallback(heth);
-#endif
+    /* ETH WAKEUP callback */
+    HAL_ETH_WakeUpCallback(heth);
+#endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
   }
-#endif
+#endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
 }
 
 /**
@@ -1686,32 +2047,17 @@ __weak void HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth)
 }
 
 /**
-  * @brief  Ethernet DMA transfer error callbacks
+  * @brief  Ethernet transfer error callbacks
   * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
   *         the configuration information for ETHERNET module
   * @retval None
   */
-__weak void HAL_ETH_DMAErrorCallback(ETH_HandleTypeDef *heth)
+__weak void HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(heth);
   /* NOTE : This function Should not be modified, when the callback is needed,
-  the HAL_ETH_DMAErrorCallback could be implemented in the user file
-  */
-}
-
-/**
-* @brief  Ethernet MAC transfer error callbacks
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-__weak void HAL_ETH_MACErrorCallback(ETH_HandleTypeDef *heth)
-{
-  /* Prevent unused argument(s) compilation warning */
-  UNUSED(heth);
-  /* NOTE : This function Should not be modified, when the callback is needed,
-  the HAL_ETH_MACErrorCallback could be implemented in the user file
+  the HAL_ETH_ErrorCallback could be implemented in the user file
   */
 }
 
@@ -1769,12 +2115,14 @@ __weak void HAL_ETH_WakeUpCallback(ETH_HandleTypeDef *heth)
   * @param pRegValue: parameter to hold read value
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint32_t PHYReg, uint32_t *pRegValue)
+HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint32_t PHYReg,
+                                          uint32_t *pRegValue)
 {
-  uint32_t tmpreg, tickstart;
+  uint32_t tickstart;
+  uint32_t tmpreg;
 
   /* Check for the Busy flag */
-  if(READ_BIT(heth->Instance->MACMDIOAR, ETH_MACMDIOAR_MB) != 0U)
+  if (READ_BIT(heth->Instance->MACMDIOAR, ETH_MACMDIOAR_MB) != (uint32_t)RESET)
   {
     return HAL_ERROR;
   }
@@ -1788,7 +2136,7 @@ HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYA
      - Set the read mode
      - Set the MII Busy bit */
 
-  MODIFY_REG(tmpreg, ETH_MACMDIOAR_PA, (PHYAddr <<21));
+  MODIFY_REG(tmpreg, ETH_MACMDIOAR_PA, (PHYAddr << 21));
   MODIFY_REG(tmpreg, ETH_MACMDIOAR_RDA, (PHYReg << 16));
   MODIFY_REG(tmpreg, ETH_MACMDIOAR_MOC, ETH_MACMDIOAR_MOC_RD);
   SET_BIT(tmpreg, ETH_MACMDIOAR_MB);
@@ -1799,9 +2147,9 @@ HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYA
   tickstart = HAL_GetTick();
 
   /* Wait for the Busy flag */
-  while(READ_BIT(heth->Instance->MACMDIOAR, ETH_MACMDIOAR_MB) > 0U)
+  while (READ_BIT(heth->Instance->MACMDIOAR, ETH_MACMDIOAR_MB) > 0U)
   {
-    if(((HAL_GetTick() - tickstart ) > ETH_MDIO_BUS_TIMEOUT))
+    if (((HAL_GetTick() - tickstart) > ETH_MDIO_BUS_TIMEOUT))
     {
       return HAL_ERROR;
     }
@@ -1823,12 +2171,14 @@ HAL_StatusTypeDef HAL_ETH_ReadPHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYA
   * @param  RegValue: the value to write
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETH_WritePHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint32_t PHYReg, uint32_t RegValue)
+HAL_StatusTypeDef HAL_ETH_WritePHYRegister(ETH_HandleTypeDef *heth, uint32_t PHYAddr, uint32_t PHYReg,
+                                           uint32_t RegValue)
 {
-  uint32_t tmpreg, tickstart;
+  uint32_t tickstart;
+  uint32_t tmpreg;
 
   /* Check for the Busy flag */
-  if(READ_BIT(heth->Instance->MACMDIOAR, ETH_MACMDIOAR_MB) != 0U)
+  if (READ_BIT(heth->Instance->MACMDIOAR, ETH_MACMDIOAR_MB) != (uint32_t)RESET)
   {
     return HAL_ERROR;
   }
@@ -1842,7 +2192,7 @@ HAL_StatusTypeDef HAL_ETH_WritePHYRegister(ETH_HandleTypeDef *heth, uint32_t PHY
      - Set the write mode
      - Set the MII Busy bit */
 
-  MODIFY_REG(tmpreg, ETH_MACMDIOAR_PA, (PHYAddr <<21));
+  MODIFY_REG(tmpreg, ETH_MACMDIOAR_PA, (PHYAddr << 21));
   MODIFY_REG(tmpreg, ETH_MACMDIOAR_RDA, (PHYReg << 16));
   MODIFY_REG(tmpreg, ETH_MACMDIOAR_MOC, ETH_MACMDIOAR_MOC_WR);
   SET_BIT(tmpreg, ETH_MACMDIOAR_MB);
@@ -1857,9 +2207,9 @@ HAL_StatusTypeDef HAL_ETH_WritePHYRegister(ETH_HandleTypeDef *heth, uint32_t PHY
   tickstart = HAL_GetTick();
 
   /* Wait for the Busy flag */
-  while(READ_BIT(heth->Instance->MACMDIOAR, ETH_MACMDIOAR_MB) > 0U)
+  while (READ_BIT(heth->Instance->MACMDIOAR, ETH_MACMDIOAR_MB) > 0U)
   {
-    if(((HAL_GetTick() - tickstart ) > ETH_MDIO_BUS_TIMEOUT))
+    if (((HAL_GetTick() - tickstart) > ETH_MDIO_BUS_TIMEOUT))
     {
       return HAL_ERROR;
     }
@@ -1903,22 +2253,25 @@ HAL_StatusTypeDef HAL_ETH_GetMACConfig(ETH_HandleTypeDef *heth, ETH_MACConfigTyp
 
   /* Get MAC parameters */
   macconf->PreambleLength = READ_BIT(heth->Instance->MACCR, ETH_MACCR_PRELEN);
-  macconf->DeferralCheck = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_DC)>> 4) > 0U) ? ENABLE : DISABLE;
+  macconf->DeferralCheck = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_DC) >> 4) > 0U) ? ENABLE : DISABLE;
   macconf->BackOffLimit = READ_BIT(heth->Instance->MACCR, ETH_MACCR_BL);
   macconf->RetryTransmission = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_DR) >> 8) == 0U) ? ENABLE : DISABLE;
-  macconf->CarrierSenseDuringTransmit = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_DCRS) >> 9) > 0U) ? ENABLE : DISABLE;
+  macconf->CarrierSenseDuringTransmit = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_DCRS) >> 9) > 0U)
+                                        ? ENABLE : DISABLE;
   macconf->ReceiveOwn = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_DO) >> 10) == 0U) ? ENABLE : DISABLE;
-  macconf->CarrierSenseBeforeTransmit = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_ECRSFD) >> 11) > 0U) ? ENABLE : DISABLE;
+  macconf->CarrierSenseBeforeTransmit = ((READ_BIT(heth->Instance->MACCR,
+                                                   ETH_MACCR_ECRSFD) >> 11) > 0U) ? ENABLE : DISABLE;
   macconf->LoopbackMode = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_LM) >> 12) > 0U) ? ENABLE : DISABLE;
   macconf->DuplexMode = READ_BIT(heth->Instance->MACCR, ETH_MACCR_DM);
   macconf->Speed = READ_BIT(heth->Instance->MACCR, ETH_MACCR_FES);
   macconf->JumboPacket = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_JE) >> 16) > 0U) ? ENABLE : DISABLE;
-  macconf->Jabber = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_JD) >>17) == 0U) ? ENABLE : DISABLE;
-  macconf->Watchdog = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_WD) >>19) == 0U) ? ENABLE : DISABLE;
+  macconf->Jabber = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_JD) >> 17) == 0U) ? ENABLE : DISABLE;
+  macconf->Watchdog = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_WD) >> 19) == 0U) ? ENABLE : DISABLE;
   macconf->AutomaticPadCRCStrip = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_ACS) >> 20) > 0U) ? ENABLE : DISABLE;
   macconf->CRCStripTypePacket = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_CST) >> 21) > 0U) ? ENABLE : DISABLE;
   macconf->Support2KPacket = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_S2KP) >> 22) > 0U) ? ENABLE : DISABLE;
-  macconf->GiantPacketSizeLimitControl = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_GPSLCE) >> 23) > 0U) ? ENABLE : DISABLE;
+  macconf->GiantPacketSizeLimitControl = ((READ_BIT(heth->Instance->MACCR,
+                                                    ETH_MACCR_GPSLCE) >> 23) > 0U) ? ENABLE : DISABLE;
   macconf->InterPacketGapVal = READ_BIT(heth->Instance->MACCR, ETH_MACCR_IPG);
   macconf->ChecksumOffload = ((READ_BIT(heth->Instance->MACCR, ETH_MACCR_IPC) >> 27) > 0U) ? ENABLE : DISABLE;
   macconf->SourceAddrControl = READ_BIT(heth->Instance->MACCR, ETH_MACCR_SARC);
@@ -1926,8 +2279,10 @@ HAL_StatusTypeDef HAL_ETH_GetMACConfig(ETH_HandleTypeDef *heth, ETH_MACConfigTyp
   macconf->GiantPacketSizeLimit = READ_BIT(heth->Instance->MACECR, ETH_MACECR_GPSL);
   macconf->CRCCheckingRxPackets = ((READ_BIT(heth->Instance->MACECR, ETH_MACECR_DCRCC) >> 16) == 0U) ? ENABLE : DISABLE;
   macconf->SlowProtocolDetect = ((READ_BIT(heth->Instance->MACECR, ETH_MACECR_SPEN) >> 17) > 0U) ? ENABLE : DISABLE;
-  macconf->UnicastSlowProtocolPacketDetect = ((READ_BIT(heth->Instance->MACECR, ETH_MACECR_USP) >> 18) > 0U) ? ENABLE : DISABLE;
-  macconf->ExtendedInterPacketGap = ((READ_BIT(heth->Instance->MACECR, ETH_MACECR_EIPGEN) >> 24) > 0U) ? ENABLE : DISABLE;
+  macconf->UnicastSlowProtocolPacketDetect = ((READ_BIT(heth->Instance->MACECR,
+                                                        ETH_MACECR_USP) >> 18) > 0U) ? ENABLE : DISABLE;
+  macconf->ExtendedInterPacketGap = ((READ_BIT(heth->Instance->MACECR, ETH_MACECR_EIPGEN) >> 24) > 0U)
+                                    ? ENABLE : DISABLE;
   macconf->ExtendedInterPacketGapVal = READ_BIT(heth->Instance->MACECR, ETH_MACECR_EIPG) >> 25;
 
 
@@ -1941,14 +2296,17 @@ HAL_StatusTypeDef HAL_ETH_GetMACConfig(ETH_HandleTypeDef *heth, ETH_MACConfigTyp
 
 
   macconf->ReceiveFlowControl = (READ_BIT(heth->Instance->MACRFCR, ETH_MACRFCR_RFE) > 0U) ? ENABLE : DISABLE;
-  macconf->UnicastPausePacketDetect = ((READ_BIT(heth->Instance->MACRFCR, ETH_MACRFCR_UP) >> 1) > 0U) ? ENABLE : DISABLE;
+  macconf->UnicastPausePacketDetect = ((READ_BIT(heth->Instance->MACRFCR, ETH_MACRFCR_UP) >> 1) > 0U)
+                                      ? ENABLE : DISABLE;
 
   macconf->TransmitQueueMode = READ_BIT(heth->Instance->MTLTQOMR, (ETH_MTLTQOMR_TTC | ETH_MTLTQOMR_TSF));
 
   macconf->ReceiveQueueMode = READ_BIT(heth->Instance->MTLRQOMR, (ETH_MTLRQOMR_RTC | ETH_MTLRQOMR_RSF));
-  macconf->ForwardRxUndersizedGoodPacket = ((READ_BIT(heth->Instance->MTLRQOMR, ETH_MTLRQOMR_FUP) >> 3) > 0U) ? ENABLE : DISABLE;
+  macconf->ForwardRxUndersizedGoodPacket = ((READ_BIT(heth->Instance->MTLRQOMR,
+                                                      ETH_MTLRQOMR_FUP) >> 3) > 0U) ? ENABLE : DISABLE;
   macconf->ForwardRxErrorPacket = ((READ_BIT(heth->Instance->MTLRQOMR, ETH_MTLRQOMR_FEP) >> 4) > 0U) ? ENABLE : DISABLE;
-  macconf->DropTCPIPChecksumErrorPacket = ((READ_BIT(heth->Instance->MTLRQOMR, ETH_MTLRQOMR_DISTCPEF) >> 6) == 0U) ? ENABLE : DISABLE;
+  macconf->DropTCPIPChecksumErrorPacket = ((READ_BIT(heth->Instance->MTLRQOMR,
+                                                     ETH_MTLRQOMR_DISTCPEF) >> 6) == 0U) ? ENABLE : DISABLE;
 
   return HAL_OK;
 }
@@ -1970,11 +2328,11 @@ HAL_StatusTypeDef HAL_ETH_GetDMAConfig(ETH_HandleTypeDef *heth, ETH_DMAConfigTyp
 
   dmaconf->AddressAlignedBeats = ((READ_BIT(heth->Instance->DMASBMR, ETH_DMASBMR_AAL) >> 12) > 0U) ? ENABLE : DISABLE;
   dmaconf->BurstMode = READ_BIT(heth->Instance->DMASBMR, ETH_DMASBMR_FB | ETH_DMASBMR_MB);
-  dmaconf->RebuildINCRxBurst = ((READ_BIT(heth->Instance->DMASBMR, ETH_DMASBMR_RB)>> 15) > 0U) ? ENABLE : DISABLE;
+  dmaconf->RebuildINCRxBurst = ((READ_BIT(heth->Instance->DMASBMR, ETH_DMASBMR_RB) >> 15) > 0U) ? ENABLE : DISABLE;
 
-  dmaconf->DMAArbitration = READ_BIT(heth->Instance->DMAMR, (ETH_DMAMR_TXPR |ETH_DMAMR_PR | ETH_DMAMR_DA));
+  dmaconf->DMAArbitration = READ_BIT(heth->Instance->DMAMR, (ETH_DMAMR_TXPR | ETH_DMAMR_PR | ETH_DMAMR_DA));
 
-  dmaconf->PBLx8Mode =  ((READ_BIT(heth->Instance->DMACCR, ETH_DMACCR_8PBL)>> 16) > 0U) ? ENABLE : DISABLE;
+  dmaconf->PBLx8Mode = ((READ_BIT(heth->Instance->DMACCR, ETH_DMACCR_8PBL) >> 16) > 0U) ? ENABLE : DISABLE;
   dmaconf->MaximumSegmentSize = READ_BIT(heth->Instance->DMACCR, ETH_DMACCR_MSS);
 
   dmaconf->FlushRxPacket = ((READ_BIT(heth->Instance->DMACRCR,  ETH_DMACRCR_RPF) >> 31) > 0U) ? ENABLE : DISABLE;
@@ -1983,7 +2341,6 @@ HAL_StatusTypeDef HAL_ETH_GetDMAConfig(ETH_HandleTypeDef *heth, ETH_DMAConfigTyp
   dmaconf->SecondPacketOperate = ((READ_BIT(heth->Instance->DMACTCR, ETH_DMACTCR_OSP) >> 4) > 0U) ? ENABLE : DISABLE;
   dmaconf->TCPSegmentation = ((READ_BIT(heth->Instance->DMACTCR, ETH_DMACTCR_TSE) >> 12) > 0U) ? ENABLE : DISABLE;
   dmaconf->TxDMABurstLength = READ_BIT(heth->Instance->DMACTCR, ETH_DMACTCR_TPBL);
-
   return HAL_OK;
 }
 
@@ -1997,12 +2354,12 @@ HAL_StatusTypeDef HAL_ETH_GetDMAConfig(ETH_HandleTypeDef *heth, ETH_DMAConfigTyp
   */
 HAL_StatusTypeDef HAL_ETH_SetMACConfig(ETH_HandleTypeDef *heth,  ETH_MACConfigTypeDef *macconf)
 {
-  if(macconf == NULL)
+  if (macconf == NULL)
   {
     return HAL_ERROR;
   }
 
-  if(heth->RxState == HAL_ETH_STATE_READY)
+  if (heth->gState == HAL_ETH_STATE_READY)
   {
     ETH_SetMACConfig(heth, macconf);
 
@@ -2024,12 +2381,12 @@ HAL_StatusTypeDef HAL_ETH_SetMACConfig(ETH_HandleTypeDef *heth,  ETH_MACConfigTy
   */
 HAL_StatusTypeDef HAL_ETH_SetDMAConfig(ETH_HandleTypeDef *heth,  ETH_DMAConfigTypeDef *dmaconf)
 {
-  if(dmaconf == NULL)
+  if (dmaconf == NULL)
   {
     return HAL_ERROR;
   }
 
-  if(heth->RxState == HAL_ETH_STATE_READY)
+  if (heth->gState == HAL_ETH_STATE_READY)
   {
     ETH_SetDMAConfig(heth, dmaconf);
 
@@ -2049,34 +2406,35 @@ HAL_StatusTypeDef HAL_ETH_SetDMAConfig(ETH_HandleTypeDef *heth,  ETH_DMAConfigTy
   */
 void HAL_ETH_SetMDIOClockRange(ETH_HandleTypeDef *heth)
 {
-  uint32_t tmpreg, hclk;
+  uint32_t hclk;
+  uint32_t tmpreg;
 
   /* Get the ETHERNET MACMDIOAR value */
   tmpreg = (heth->Instance)->MACMDIOAR;
 
-	/* Clear CSR Clock Range bits */
+  /* Clear CSR Clock Range bits */
   tmpreg &= ~ETH_MACMDIOAR_CR;
 
-	/* Get hclk frequency value */
+  /* Get hclk frequency value */
   hclk = HAL_RCC_GetHCLKFreq();
 
-	/* Set CR bits depending on hclk value */
-  if((hclk >= 20000000U)&&(hclk < 35000000U))
+  /* Set CR bits depending on hclk value */
+  if ((hclk >= 20000000U) && (hclk < 35000000U))
   {
     /* CSR Clock Range between 20-35 MHz */
     tmpreg |= (uint32_t)ETH_MACMDIOAR_CR_DIV16;
   }
-  else if((hclk >= 35000000U)&&(hclk < 60000000U))
+  else if ((hclk >= 35000000U) && (hclk < 60000000U))
   {
     /* CSR Clock Range between 35-60 MHz */
     tmpreg |= (uint32_t)ETH_MACMDIOAR_CR_DIV26;
   }
-  else if((hclk >= 60000000U)&&(hclk < 100000000U))
+  else if ((hclk >= 60000000U) && (hclk < 100000000U))
   {
     /* CSR Clock Range between 60-100 MHz */
     tmpreg |= (uint32_t)ETH_MACMDIOAR_CR_DIV42;
   }
-  else if((hclk >= 100000000U)&&(hclk < 150000000U))
+  else if ((hclk >= 100000000U) && (hclk < 150000000U))
   {
     /* CSR Clock Range between 100-150 MHz */
     tmpreg |= (uint32_t)ETH_MACMDIOAR_CR_DIV62;
@@ -2103,22 +2461,22 @@ HAL_StatusTypeDef HAL_ETH_SetMACFilterConfig(ETH_HandleTypeDef *heth, ETH_MACFil
 {
   uint32_t filterconfig;
 
-  if(pFilterConfig == NULL)
+  if (pFilterConfig == NULL)
   {
     return HAL_ERROR;
   }
 
   filterconfig = ((uint32_t)pFilterConfig->PromiscuousMode |
                   ((uint32_t)pFilterConfig->HashUnicast << 1) |
-                    ((uint32_t)pFilterConfig->HashMulticast << 2)  |
-                      ((uint32_t)pFilterConfig->DestAddrInverseFiltering << 3) |
-                        ((uint32_t)pFilterConfig->PassAllMulticast << 4) |
-                          ((uint32_t)((pFilterConfig->BroadcastFilter == DISABLE) ? 1U : 0U) << 5) |
-                            ((uint32_t)pFilterConfig->SrcAddrInverseFiltering << 8) |
-                              ((uint32_t)pFilterConfig->SrcAddrFiltering << 9) |
-                                ((uint32_t)pFilterConfig->HachOrPerfectFilter << 10) |
-                                  ((uint32_t)pFilterConfig->ReceiveAllMode << 31) |
-                                    pFilterConfig->ControlPacketsFilter);
+                  ((uint32_t)pFilterConfig->HashMulticast << 2)  |
+                  ((uint32_t)pFilterConfig->DestAddrInverseFiltering << 3) |
+                  ((uint32_t)pFilterConfig->PassAllMulticast << 4) |
+                  ((uint32_t)((pFilterConfig->BroadcastFilter == DISABLE) ? 1U : 0U) << 5) |
+                  ((uint32_t)pFilterConfig->SrcAddrInverseFiltering << 8) |
+                  ((uint32_t)pFilterConfig->SrcAddrFiltering << 9) |
+                  ((uint32_t)pFilterConfig->HachOrPerfectFilter << 10) |
+                  ((uint32_t)pFilterConfig->ReceiveAllMode << 31) |
+                  pFilterConfig->ControlPacketsFilter);
 
   MODIFY_REG(heth->Instance->MACPFR, ETH_MACPFR_MASK, filterconfig);
 
@@ -2135,7 +2493,7 @@ HAL_StatusTypeDef HAL_ETH_SetMACFilterConfig(ETH_HandleTypeDef *heth, ETH_MACFil
   */
 HAL_StatusTypeDef HAL_ETH_GetMACFilterConfig(ETH_HandleTypeDef *heth, ETH_MACFilterConfigTypeDef *pFilterConfig)
 {
-  if(pFilterConfig == NULL)
+  if (pFilterConfig == NULL)
   {
     return HAL_ERROR;
   }
@@ -2143,13 +2501,16 @@ HAL_StatusTypeDef HAL_ETH_GetMACFilterConfig(ETH_HandleTypeDef *heth, ETH_MACFil
   pFilterConfig->PromiscuousMode = ((READ_BIT(heth->Instance->MACPFR, ETH_MACPFR_PR)) > 0U) ? ENABLE : DISABLE;
   pFilterConfig->HashUnicast = ((READ_BIT(heth->Instance->MACPFR, ETH_MACPFR_HUC) >> 1) > 0U) ? ENABLE : DISABLE;
   pFilterConfig->HashMulticast = ((READ_BIT(heth->Instance->MACPFR, ETH_MACPFR_HMC) >> 2) > 0U) ? ENABLE : DISABLE;
-  pFilterConfig->DestAddrInverseFiltering = ((READ_BIT(heth->Instance->MACPFR, ETH_MACPFR_DAIF) >> 3) > 0U) ? ENABLE : DISABLE;
+  pFilterConfig->DestAddrInverseFiltering = ((READ_BIT(heth->Instance->MACPFR,
+                                                       ETH_MACPFR_DAIF) >> 3) > 0U) ? ENABLE : DISABLE;
   pFilterConfig->PassAllMulticast = ((READ_BIT(heth->Instance->MACPFR, ETH_MACPFR_PM) >> 4) > 0U) ? ENABLE : DISABLE;
   pFilterConfig->BroadcastFilter = ((READ_BIT(heth->Instance->MACPFR, ETH_MACPFR_DBF) >> 5) == 0U) ? ENABLE : DISABLE;
   pFilterConfig->ControlPacketsFilter = READ_BIT(heth->Instance->MACPFR, ETH_MACPFR_PCF);
-  pFilterConfig->SrcAddrInverseFiltering = ((READ_BIT(heth->Instance->MACPFR, ETH_MACPFR_SAIF) >> 8) > 0U) ? ENABLE : DISABLE;
+  pFilterConfig->SrcAddrInverseFiltering = ((READ_BIT(heth->Instance->MACPFR,
+                                                      ETH_MACPFR_SAIF) >> 8) > 0U) ? ENABLE : DISABLE;
   pFilterConfig->SrcAddrFiltering = ((READ_BIT(heth->Instance->MACPFR, ETH_MACPFR_SAF) >> 9) > 0U) ? ENABLE : DISABLE;
-  pFilterConfig->HachOrPerfectFilter = ((READ_BIT(heth->Instance->MACPFR, ETH_MACPFR_HPF) >> 10) > 0U) ? ENABLE : DISABLE;
+  pFilterConfig->HachOrPerfectFilter = ((READ_BIT(heth->Instance->MACPFR, ETH_MACPFR_HPF) >> 10) > 0U)
+                                       ? ENABLE : DISABLE;
   pFilterConfig->ReceiveAllMode = ((READ_BIT(heth->Instance->MACPFR, ETH_MACPFR_RA) >> 31) > 0U) ? ENABLE : DISABLE;
 
   return HAL_OK;
@@ -2169,17 +2530,18 @@ HAL_StatusTypeDef HAL_ETH_GetMACFilterConfig(ETH_HandleTypeDef *heth, ETH_MACFil
   */
 HAL_StatusTypeDef HAL_ETH_SetSourceMACAddrMatch(ETH_HandleTypeDef *heth, uint32_t AddrNbr, uint8_t *pMACAddr)
 {
-  uint32_t macaddrhr, macaddrlr;
+  uint32_t macaddrlr;
+  uint32_t macaddrhr;
 
-  if(pMACAddr == NULL)
+  if (pMACAddr == NULL)
   {
     return HAL_ERROR;
   }
 
   /* Get mac addr high reg offset */
-  macaddrhr = ((uint32_t)&(heth->Instance->MACA0HR) + AddrNbr);
+  macaddrhr = ((uint32_t) &(heth->Instance->MACA0HR) + AddrNbr);
   /* Get mac addr low reg offset */
-  macaddrlr = ((uint32_t)&(heth->Instance->MACA0LR) + AddrNbr);
+  macaddrlr = ((uint32_t) &(heth->Instance->MACA0LR) + AddrNbr);
 
   /* Set MAC addr bits 32 to 47 */
   (*(__IO uint32_t *)macaddrhr) = (((uint32_t)(pMACAddr[5]) << 8) | (uint32_t)pMACAddr[4]);
@@ -2187,7 +2549,7 @@ HAL_StatusTypeDef HAL_ETH_SetSourceMACAddrMatch(ETH_HandleTypeDef *heth, uint32_
   (*(__IO uint32_t *)macaddrlr) = (((uint32_t)(pMACAddr[3]) << 24) | ((uint32_t)(pMACAddr[2]) << 16) |
                                    ((uint32_t)(pMACAddr[1]) << 8) | (uint32_t)pMACAddr[0]);
 
-   /* Enable address and set source address bit */
+  /* Enable address and set source address bit */
   (*(__IO uint32_t *)macaddrhr) |= (ETH_MACAHR_SA | ETH_MACAHR_AE);
 
   return HAL_OK;
@@ -2203,7 +2565,7 @@ HAL_StatusTypeDef HAL_ETH_SetSourceMACAddrMatch(ETH_HandleTypeDef *heth, uint32_
   */
 HAL_StatusTypeDef HAL_ETH_SetHashTable(ETH_HandleTypeDef *heth, uint32_t *pHashTable)
 {
-  if(pHashTable == NULL)
+  if (pHashTable == NULL)
   {
     return HAL_ERROR;
   }
@@ -2225,14 +2587,14 @@ HAL_StatusTypeDef HAL_ETH_SetHashTable(ETH_HandleTypeDef *heth, uint32_t *pHashT
   */
 void HAL_ETH_SetRxVLANIdentifier(ETH_HandleTypeDef *heth, uint32_t ComparisonBits, uint32_t VLANIdentifier)
 {
-  if(ComparisonBits == ETH_VLANTAGCOMPARISON_16BIT)
+  if (ComparisonBits == ETH_VLANTAGCOMPARISON_16BIT)
   {
-    MODIFY_REG(heth->Instance->MACVTR, ETH_MACVTR_VL , VLANIdentifier);
+    MODIFY_REG(heth->Instance->MACVTR, ETH_MACVTR_VL, VLANIdentifier);
     CLEAR_BIT(heth->Instance->MACVTR, ETH_MACVTR_ETV);
   }
   else
   {
-    MODIFY_REG(heth->Instance->MACVTR, ETH_MACVTR_VL_VID , VLANIdentifier);
+    MODIFY_REG(heth->Instance->MACVTR, ETH_MACVTR_VL_VID, VLANIdentifier);
     SET_BIT(heth->Instance->MACVTR, ETH_MACVTR_ETV);
   }
 }
@@ -2251,9 +2613,9 @@ void HAL_ETH_EnterPowerDownMode(ETH_HandleTypeDef *heth, ETH_PowerDownConfigType
 
   powerdownconfig = (((uint32_t)pPowerDownConfig->MagicPacket << 1) |
                      ((uint32_t)pPowerDownConfig->WakeUpPacket << 2) |
-                       ((uint32_t)pPowerDownConfig->GlobalUnicast << 9) |
-                         ((uint32_t)pPowerDownConfig->WakeUpForward << 10) |
-                           ETH_MACPCSR_PWRDWN);
+                     ((uint32_t)pPowerDownConfig->GlobalUnicast << 9) |
+                     ((uint32_t)pPowerDownConfig->WakeUpForward << 10) |
+                     ETH_MACPCSR_PWRDWN);
 
   /* Enable PMT interrupt */
   __HAL_ETH_MAC_ENABLE_IT(heth, ETH_MACIER_PMTIE);
@@ -2270,9 +2632,10 @@ void HAL_ETH_EnterPowerDownMode(ETH_HandleTypeDef *heth, ETH_PowerDownConfigType
 void HAL_ETH_ExitPowerDownMode(ETH_HandleTypeDef *heth)
 {
   /* clear wake up sources */
-  CLEAR_BIT(heth->Instance->MACPCSR, ETH_MACPCSR_RWKPKTEN | ETH_MACPCSR_MGKPKTEN | ETH_MACPCSR_GLBLUCAST | ETH_MACPCSR_RWKPFE);
+  CLEAR_BIT(heth->Instance->MACPCSR, ETH_MACPCSR_RWKPKTEN | ETH_MACPCSR_MGKPKTEN | ETH_MACPCSR_GLBLUCAST |
+            ETH_MACPCSR_RWKPFE);
 
-  if(READ_BIT(heth->Instance->MACPCSR, ETH_MACPCSR_PWRDWN) != 0U)
+  if (READ_BIT(heth->Instance->MACPCSR, ETH_MACPCSR_PWRDWN) != (uint32_t)RESET)
   {
     /* Exit power down mode */
     CLEAR_BIT(heth->Instance->MACPCSR, ETH_MACPCSR_PWRDWN);
@@ -2294,7 +2657,7 @@ HAL_StatusTypeDef HAL_ETH_SetWakeUpFilter(ETH_HandleTypeDef *heth, uint32_t *pFi
 {
   uint32_t regindex;
 
-  if(pFilter == NULL)
+  if (pFilter == NULL)
   {
     return HAL_ERROR;
   }
@@ -2303,7 +2666,7 @@ HAL_StatusTypeDef HAL_ETH_SetWakeUpFilter(ETH_HandleTypeDef *heth, uint32_t *pFi
   SET_BIT(heth->Instance->MACPCSR, ETH_MACPCSR_RWKFILTRST);
 
   /* Wake up packet filter config */
-  for(regindex = 0; regindex < Count; regindex++)
+  for (regindex = 0; regindex < Count; regindex++)
   {
     /* Write filter regs */
     WRITE_REG(heth->Instance->MACRWKPFR, pFilter[regindex]);
@@ -2341,13 +2704,7 @@ HAL_StatusTypeDef HAL_ETH_SetWakeUpFilter(ETH_HandleTypeDef *heth, uint32_t *pFi
   */
 HAL_ETH_StateTypeDef HAL_ETH_GetState(ETH_HandleTypeDef *heth)
 {
-  HAL_ETH_StateTypeDef ret;
-  HAL_ETH_StateTypeDef gstate = heth->gState;
-  HAL_ETH_StateTypeDef rxstate =heth->RxState;
-
-  ret = gstate;
-  ret |= rxstate;
-  return ret;
+  return heth->gState;
 }
 
 /**
@@ -2406,42 +2763,43 @@ uint32_t HAL_ETH_GetMACWakeUpSource(ETH_HandleTypeDef *heth)
   * @{
   */
 
+
 static void ETH_SetMACConfig(ETH_HandleTypeDef *heth,  ETH_MACConfigTypeDef *macconf)
 {
   uint32_t macregval;
 
   /*------------------------ MACCR Configuration --------------------*/
-  macregval =(macconf->InterPacketGapVal |
-              macconf->SourceAddrControl |
-                ((uint32_t)macconf->ChecksumOffload<< 27) |
-                  ((uint32_t)macconf->GiantPacketSizeLimitControl << 23) |
-                    ((uint32_t)macconf->Support2KPacket  << 22) |
-                      ((uint32_t)macconf->CRCStripTypePacket << 21) |
-                        ((uint32_t)macconf->AutomaticPadCRCStrip << 20) |
-                          ((uint32_t)((macconf->Watchdog == DISABLE) ? 1U : 0U) << 19) |
-                            ((uint32_t)((macconf->Jabber == DISABLE) ? 1U : 0U) << 17) |
-                              ((uint32_t)macconf->JumboPacket << 16) |
-                                macconf->Speed |
-                                  macconf->DuplexMode |
-                                    ((uint32_t)macconf->LoopbackMode << 12) |
-                                      ((uint32_t)macconf->CarrierSenseBeforeTransmit << 11)|
-                                        ((uint32_t)((macconf->ReceiveOwn == DISABLE) ? 1U : 0U) << 10)|
-                                          ((uint32_t)macconf->CarrierSenseDuringTransmit << 9)|
-                                            ((uint32_t)((macconf->RetryTransmission == DISABLE) ? 1U : 0U) << 8)|
-                                              macconf->BackOffLimit |
-                                                ((uint32_t)macconf->DeferralCheck << 4)|
-                                                  macconf->PreambleLength);
+  macregval = (macconf->InterPacketGapVal |
+               macconf->SourceAddrControl |
+               ((uint32_t)macconf->ChecksumOffload << 27) |
+               ((uint32_t)macconf->GiantPacketSizeLimitControl << 23) |
+               ((uint32_t)macconf->Support2KPacket  << 22) |
+               ((uint32_t)macconf->CRCStripTypePacket << 21) |
+               ((uint32_t)macconf->AutomaticPadCRCStrip << 20) |
+               ((uint32_t)((macconf->Watchdog == DISABLE) ? 1U : 0U) << 19) |
+               ((uint32_t)((macconf->Jabber == DISABLE) ? 1U : 0U) << 17) |
+               ((uint32_t)macconf->JumboPacket << 16) |
+               macconf->Speed |
+               macconf->DuplexMode |
+               ((uint32_t)macconf->LoopbackMode << 12) |
+               ((uint32_t)macconf->CarrierSenseBeforeTransmit << 11) |
+               ((uint32_t)((macconf->ReceiveOwn == DISABLE) ? 1U : 0U) << 10) |
+               ((uint32_t)macconf->CarrierSenseDuringTransmit << 9) |
+               ((uint32_t)((macconf->RetryTransmission == DISABLE) ? 1U : 0U) << 8) |
+               macconf->BackOffLimit |
+               ((uint32_t)macconf->DeferralCheck << 4) |
+               macconf->PreambleLength);
 
   /* Write to MACCR */
   MODIFY_REG(heth->Instance->MACCR, ETH_MACCR_MASK, macregval);
 
   /*------------------------ MACECR Configuration --------------------*/
-  macregval = ((macconf->ExtendedInterPacketGapVal << 25)|
-               ((uint32_t)macconf->ExtendedInterPacketGap << 24)|
-                 ((uint32_t)macconf->UnicastSlowProtocolPacketDetect << 18)|
-                   ((uint32_t)macconf->SlowProtocolDetect << 17)|
-                     ((uint32_t)((macconf->CRCCheckingRxPackets == DISABLE) ? 1U : 0U)<< 16) |
-                       macconf->GiantPacketSizeLimit);
+  macregval = ((macconf->ExtendedInterPacketGapVal << 25) |
+               ((uint32_t)macconf->ExtendedInterPacketGap << 24) |
+               ((uint32_t)macconf->UnicastSlowProtocolPacketDetect << 18) |
+               ((uint32_t)macconf->SlowProtocolDetect << 17) |
+               ((uint32_t)((macconf->CRCCheckingRxPackets == DISABLE) ? 1U : 0U) << 16) |
+               macconf->GiantPacketSizeLimit);
 
   /* Write to MACECR */
   MODIFY_REG(heth->Instance->MACECR, ETH_MACECR_MASK, macregval);
@@ -2456,8 +2814,8 @@ static void ETH_SetMACConfig(ETH_HandleTypeDef *heth,  ETH_MACConfigTypeDef *mac
   /*------------------------ MACTFCR Configuration --------------------*/
   macregval = (((uint32_t)macconf->TransmitFlowControl << 1) |
                macconf->PauseLowThreshold |
-                 ((uint32_t)((macconf->ZeroQuantaPause == DISABLE) ? 1U : 0U)<< 7) |
-                   (macconf->PauseTime << 16));
+               ((uint32_t)((macconf->ZeroQuantaPause == DISABLE) ? 1U : 0U) << 7) |
+               (macconf->PauseTime << 16));
 
   /* Write to MACTFCR */
   MODIFY_REG(heth->Instance->MACTFCR, ETH_MACTFCR_MASK, macregval);
@@ -2476,8 +2834,8 @@ static void ETH_SetMACConfig(ETH_HandleTypeDef *heth,  ETH_MACConfigTypeDef *mac
   /*------------------------ MTLRQOMR Configuration --------------------*/
   macregval = (macconf->ReceiveQueueMode |
                ((uint32_t)((macconf->DropTCPIPChecksumErrorPacket == DISABLE) ? 1U : 0U) << 6) |
-                 ((uint32_t)macconf->ForwardRxErrorPacket << 4) |
-                   ((uint32_t)macconf->ForwardRxUndersizedGoodPacket << 3));
+               ((uint32_t)macconf->ForwardRxErrorPacket << 4) |
+               ((uint32_t)macconf->ForwardRxUndersizedGoodPacket << 3));
 
   /* Write to MTLRQOMR */
   MODIFY_REG(heth->Instance->MTLRQOMR, ETH_MTLRQOMR_MASK, macregval);
@@ -2493,7 +2851,7 @@ static void ETH_SetDMAConfig(ETH_HandleTypeDef *heth,  ETH_DMAConfigTypeDef *dma
   /*------------------------ DMASBMR Configuration --------------------*/
   dmaregval = (((uint32_t)dmaconf->AddressAlignedBeats << 12) |
                dmaconf->BurstMode |
-                 ((uint32_t)dmaconf->RebuildINCRxBurst << 15));
+               ((uint32_t)dmaconf->RebuildINCRxBurst << 15));
 
   MODIFY_REG(heth->Instance->DMASBMR, ETH_DMASBMR_MASK, dmaregval);
 
@@ -2505,8 +2863,8 @@ static void ETH_SetDMAConfig(ETH_HandleTypeDef *heth,  ETH_DMAConfigTypeDef *dma
 
   /*------------------------ DMACTCR Configuration --------------------*/
   dmaregval = (dmaconf->TxDMABurstLength |
-               ((uint32_t)dmaconf->SecondPacketOperate << 4)|
-                 ((uint32_t)dmaconf->TCPSegmentation << 12));
+               ((uint32_t)dmaconf->SecondPacketOperate << 4) |
+               ((uint32_t)dmaconf->TCPSegmentation << 12));
 
   MODIFY_REG(heth->Instance->DMACTCR, ETH_DMACTCR_MASK, dmaregval);
 
@@ -2585,62 +2943,12 @@ static void ETH_MACDMAConfig(ETH_HandleTypeDef *heth)
   dmaDefaultConf.SecondPacketOperate = DISABLE;
   dmaDefaultConf.TxDMABurstLength = ETH_TXDMABURSTLENGTH_32BEAT;
   dmaDefaultConf.TCPSegmentation = DISABLE;
-  dmaDefaultConf.MaximumSegmentSize = 536;
+  dmaDefaultConf.MaximumSegmentSize = ETH_SEGMENT_SIZE_DEFAULT;
 
   /* DMA default configuration */
   ETH_SetDMAConfig(heth, &dmaDefaultConf);
 }
 
-/**
-  * @brief  Configures the Clock range of SMI interface.
-  *         called by HAL_ETH_Init() API.
-  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
-  *         the configuration information for ETHERNET module
-  * @retval None
-  */
-static void ETH_MAC_MDIO_ClkConfig(ETH_HandleTypeDef *heth)
-{
-  uint32_t tmpreg, hclk;
-
-  /* Get the ETHERNET MACMDIOAR value */
-  tmpreg = (heth->Instance)->MACMDIOAR;
-
-  /* Clear CSR Clock Range bits */
-  tmpreg &= ~ETH_MACMDIOAR_CR;
-
-  /* Get hclk frequency value */
-  hclk = HAL_RCC_GetHCLKFreq();
-
-  /* Set CR bits depending on hclk value */
-  if((hclk >= 20000000U)&&(hclk < 35000000U))
-  {
-    /* CSR Clock Range between 20-35 MHz */
-    tmpreg |= (uint32_t)ETH_MACMDIOAR_CR_DIV16;
-  }
-  else if((hclk >= 35000000U)&&(hclk < 60000000U))
-  {
-    /* CSR Clock Range between 35-60 MHz */
-    tmpreg |= (uint32_t)ETH_MACMDIOAR_CR_DIV26;
-  }
-  else if((hclk >= 60000000U)&&(hclk < 100000000U))
-  {
-    /* CSR Clock Range between 60-100 MHz */
-    tmpreg |= (uint32_t)ETH_MACMDIOAR_CR_DIV42;
-  }
-  else if((hclk >= 100000000U)&&(hclk < 150000000U))
-  {
-    /* CSR Clock Range between 100-150 MHz */
-    tmpreg |= (uint32_t)ETH_MACMDIOAR_CR_DIV62;
-  }
-  else /* (hclk >= 150000000)&&(hclk <= 200000000) */
-  {
-    /* CSR Clock Range between 150-200 MHz */
-    tmpreg |= (uint32_t)ETH_MACMDIOAR_CR_DIV102;
-  }
-
-  /* Configure the CSR Clock Range */
-  (heth->Instance)->MACMDIOAR = (uint32_t)tmpreg;
-}
 
 /**
   * @brief  Initializes the DMA Tx descriptors.
@@ -2655,7 +2963,7 @@ static void ETH_DMATxDescListInit(ETH_HandleTypeDef *heth)
   uint32_t i;
 
   /* Fill each DMATxDesc descriptor with the right values */
-  for(i=0; i < (uint32_t)ETH_TX_DESC_CNT; i++)
+  for (i = 0; i < (uint32_t)ETH_TX_DESC_CNT; i++)
   {
     dmatxdesc = heth->Init.TxDesc + i;
 
@@ -2665,12 +2973,13 @@ static void ETH_DMATxDescListInit(ETH_HandleTypeDef *heth)
     WRITE_REG(dmatxdesc->DESC3, 0x0);
 
     WRITE_REG(heth->TxDescList.TxDesc[i], (uint32_t)dmatxdesc);
+
   }
 
   heth->TxDescList.CurTxDesc = 0;
 
   /* Set Transmit Descriptor Ring Length */
-  WRITE_REG(heth->Instance->DMACTDRLR, (ETH_TX_DESC_CNT -1));
+  WRITE_REG(heth->Instance->DMACTDRLR, (ETH_TX_DESC_CNT - 1U));
 
   /* Set Transmit Descriptor List Address */
   WRITE_REG(heth->Instance->DMACTDLAR, (uint32_t) heth->Init.TxDesc);
@@ -2691,7 +3000,7 @@ static void ETH_DMARxDescListInit(ETH_HandleTypeDef *heth)
   ETH_DMADescTypeDef *dmarxdesc;
   uint32_t i;
 
-  for(i = 0; i < (uint32_t)ETH_RX_DESC_CNT; i++)
+  for (i = 0; i < (uint32_t)ETH_RX_DESC_CNT; i++)
   {
     dmarxdesc =  heth->Init.RxDesc + i;
 
@@ -2702,24 +3011,26 @@ static void ETH_DMARxDescListInit(ETH_HandleTypeDef *heth)
     WRITE_REG(dmarxdesc->BackupAddr0, 0x0);
     WRITE_REG(dmarxdesc->BackupAddr1, 0x0);
 
+
     /* Set Rx descritors addresses */
     WRITE_REG(heth->RxDescList.RxDesc[i], (uint32_t)dmarxdesc);
+
   }
 
-  WRITE_REG(heth->RxDescList.CurRxDesc, 0);
-  WRITE_REG(heth->RxDescList.FirstAppDesc, 0);
-  WRITE_REG(heth->RxDescList.AppDescNbr, 0);
+  WRITE_REG(heth->RxDescList.RxDescIdx, 0);
+  WRITE_REG(heth->RxDescList.RxDescCnt, 0);
+  WRITE_REG(heth->RxDescList.RxBuildDescIdx, 0);
+  WRITE_REG(heth->RxDescList.RxBuildDescCnt, 0);
   WRITE_REG(heth->RxDescList.ItMode, 0);
-  WRITE_REG(heth->RxDescList.AppContextDesc, 0);
 
   /* Set Receive Descriptor Ring Length */
-  WRITE_REG(heth->Instance->DMACRDRLR, ((uint32_t)(ETH_RX_DESC_CNT - 1)));
+  WRITE_REG(heth->Instance->DMACRDRLR, ((uint32_t)(ETH_RX_DESC_CNT - 1U)));
 
   /* Set Receive Descriptor List Address */
   WRITE_REG(heth->Instance->DMACRDLAR, (uint32_t) heth->Init.RxDesc);
 
   /* Set Receive Descriptor Tail pointer Address */
-  WRITE_REG(heth->Instance->DMACRDTPR, ((uint32_t)(heth->Init.RxDesc + (uint32_t)(ETH_RX_DESC_CNT - 1))));
+  WRITE_REG(heth->Instance->DMACRDTPR, ((uint32_t)(heth->Init.RxDesc + (uint32_t)(ETH_RX_DESC_CNT - 1U))));
 }
 
 /**
@@ -2736,14 +3047,16 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
   ETH_TxDescListTypeDef *dmatxdesclist = &heth->TxDescList;
   uint32_t descidx = dmatxdesclist->CurTxDesc;
   uint32_t firstdescidx = dmatxdesclist->CurTxDesc;
-  uint32_t descnbr = 0, idx;
+  uint32_t idx;
+  uint32_t descnbr = 0;
   ETH_DMADescTypeDef *dmatxdesc = (ETH_DMADescTypeDef *)dmatxdesclist->TxDesc[descidx];
 
   ETH_BufferTypeDef  *txbuffer = pTxConfig->TxBuffer;
   uint32_t           bd_count = 0;
 
   /* Current Tx Descriptor Owned by DMA: cannot be used by the application  */
-  if((READ_BIT(dmatxdesc->DESC3, ETH_DMATXNDESCWBF_OWN) == ETH_DMATXNDESCWBF_OWN) || (dmatxdesclist->PacketAddress[descidx] != NULL))
+  if ((READ_BIT(dmatxdesc->DESC3, ETH_DMATXNDESCWBF_OWN) == ETH_DMATXNDESCWBF_OWN)
+      || (dmatxdesclist->PacketAddress[descidx] != NULL))
   {
     return HAL_ETH_ERROR_BUSY;
   }
@@ -2752,7 +3065,7 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
   /*****************    Context descriptor configuration (Optional) **********/
   /***************************************************************************/
   /* If VLAN tag is enabled for this packet */
-  if(READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_VLANTAG) != 0U)
+  if (READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_VLANTAG) != (uint32_t)RESET)
   {
     /* Set vlan tag value */
     MODIFY_REG(dmatxdesc->DESC3, ETH_DMATXCDESC_VT, pTxConfig->VlanTag);
@@ -2762,7 +3075,7 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
     SET_BIT(heth->Instance->MACVIR, ETH_MACVIR_VLTI);
 
     /* if inner VLAN is enabled */
-    if(READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_INNERVLANTAG) != 0U)
+    if (READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_INNERVLANTAG) != (uint32_t)RESET)
     {
       /* Set inner vlan tag value */
       MODIFY_REG(dmatxdesc->DESC2, ETH_DMATXCDESC_IVT, (pTxConfig->InnerVlanTag << 16));
@@ -2780,7 +3093,7 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
   }
 
   /* if tcp segmentation is enabled for this packet */
-  if(READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_TSO) != 0U)
+  if (READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_TSO) != (uint32_t)RESET)
   {
     /* Set MSS value */
     MODIFY_REG(dmatxdesc->DESC2, ETH_DMATXCDESC_MSS, pTxConfig->MaxSegmentSize);
@@ -2788,10 +3101,13 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
     SET_BIT(dmatxdesc->DESC3, ETH_DMATXCDESC_TCMSSV);
   }
 
-  if((READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_VLANTAG) != 0U)|| (READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_TSO) != 0U))
+  if ((READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_VLANTAG) != (uint32_t)RESET)
+      || (READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_TSO) != (uint32_t)RESET))
   {
     /* Set as context descriptor */
     SET_BIT(dmatxdesc->DESC3, ETH_DMATXCDESC_CTXT);
+    /* Ensure rest of descriptor is written to RAM before the OWN bit */
+    __DMB();
     /* Set own bit */
     SET_BIT(dmatxdesc->DESC3, ETH_DMATXCDESC_OWN);
     /* Increment current tx descriptor index */
@@ -2802,9 +3118,11 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
     descnbr += 1U;
 
     /* Current Tx Descriptor Owned by DMA: cannot be used by the application  */
-    if(READ_BIT(dmatxdesc->DESC3, ETH_DMATXNDESCWBF_OWN) == ETH_DMATXNDESCWBF_OWN)
+    if (READ_BIT(dmatxdesc->DESC3, ETH_DMATXNDESCWBF_OWN) == ETH_DMATXNDESCWBF_OWN)
     {
       dmatxdesc = (ETH_DMADescTypeDef *)dmatxdesclist->TxDesc[firstdescidx];
+      /* Ensure rest of descriptor is written to RAM before the OWN bit */
+      __DMB();
       /* Clear own bit */
       CLEAR_BIT(dmatxdesc->DESC3, ETH_DMATXCDESC_OWN);
 
@@ -2823,7 +3141,7 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
   /* Set header or buffer 1 Length */
   MODIFY_REG(dmatxdesc->DESC2, ETH_DMATXNDESCRF_B1L, txbuffer->len);
 
-  if(txbuffer->next != NULL)
+  if (txbuffer->next != NULL)
   {
     txbuffer = txbuffer->next;
     /* Set buffer 2 address */
@@ -2838,7 +3156,7 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
     MODIFY_REG(dmatxdesc->DESC2, ETH_DMATXNDESCRF_B2L, 0x0U);
   }
 
-  if(READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_TSO) != 0U)
+  if (READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_TSO) != (uint32_t)RESET)
   {
     /* Set TCP Header length */
     MODIFY_REG(dmatxdesc->DESC3, ETH_DMATXNDESCRF_THL, (pTxConfig->TCPHeaderLen << 19));
@@ -2851,18 +3169,18 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
   {
     MODIFY_REG(dmatxdesc->DESC3, ETH_DMATXNDESCRF_FL, pTxConfig->Length);
 
-    if(READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_CSUM) != 0U)
+    if (READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_CSUM) != (uint32_t)RESET)
     {
       MODIFY_REG(dmatxdesc->DESC3, ETH_DMATXNDESCRF_CIC, pTxConfig->ChecksumCtrl);
     }
 
-    if(READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_CRCPAD) != 0U)
+    if (READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_CRCPAD) != (uint32_t)RESET)
     {
       MODIFY_REG(dmatxdesc->DESC3, ETH_DMATXNDESCRF_CPC, pTxConfig->CRCPadCtrl);
     }
   }
 
-  if(READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_VLANTAG) != 0U)
+  if (READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_VLANTAG) != (uint32_t)RESET)
   {
     /* Set Vlan Tag control */
     MODIFY_REG(dmatxdesc->DESC2, ETH_DMATXNDESCRF_VTIR, pTxConfig->VlanCtrl);
@@ -2872,11 +3190,13 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
   SET_BIT(dmatxdesc->DESC3, ETH_DMATXNDESCRF_FD);
   /* Mark it as NORMAL descriptor */
   CLEAR_BIT(dmatxdesc->DESC3, ETH_DMATXNDESCRF_CTXT);
+  /* Ensure rest of descriptor is written to RAM before the OWN bit */
+  __DMB();
   /* set OWN bit of FIRST descriptor */
   SET_BIT(dmatxdesc->DESC3, ETH_DMATXNDESCRF_OWN);
 
   /* If source address insertion/replacement is enabled for this packet */
-  if(READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_SAIC) != 0U)
+  if (READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_SAIC) != (uint32_t)RESET)
   {
     MODIFY_REG(dmatxdesc->DESC3, ETH_DMATXNDESCRF_SAIC, pTxConfig->SrcAddrCtrl);
   }
@@ -2895,14 +3215,18 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
     CLEAR_BIT(dmatxdesc->DESC3, ETH_DMATXNDESCRF_FD);
 
     /* Current Tx Descriptor Owned by DMA: cannot be used by the application  */
-    if((READ_BIT(dmatxdesc->DESC3, ETH_DMATXNDESCRF_OWN) == ETH_DMATXNDESCRF_OWN) || (dmatxdesclist->PacketAddress[descidx] != NULL))
+    if ((READ_BIT(dmatxdesc->DESC3, ETH_DMATXNDESCRF_OWN) == ETH_DMATXNDESCRF_OWN)
+        || (dmatxdesclist->PacketAddress[descidx] != NULL))
     {
       descidx = firstdescidx;
       dmatxdesc = (ETH_DMADescTypeDef *)dmatxdesclist->TxDesc[descidx];
 
       /* clear previous desc own bit */
-      for(idx = 0; idx < descnbr; idx ++)
+      for (idx = 0; idx < descnbr; idx ++)
       {
+        /* Ensure rest of descriptor is written to RAM before the OWN bit */
+        __DMB();
+
         CLEAR_BIT(dmatxdesc->DESC3, ETH_DMATXNDESCRF_OWN);
 
         /* Increment current tx descriptor index */
@@ -2940,7 +3264,7 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
       MODIFY_REG(dmatxdesc->DESC2, ETH_DMATXNDESCRF_B2L, 0x0U);
     }
 
-    if(READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_TSO) != 0U)
+    if (READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_TSO) != (uint32_t)RESET)
     {
       /* Set TCP payload length */
       MODIFY_REG(dmatxdesc->DESC3, ETH_DMATXNDESCRF_TPL, pTxConfig->PayloadLen);
@@ -2952,7 +3276,7 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
       /* Set the packet length */
       MODIFY_REG(dmatxdesc->DESC3, ETH_DMATXNDESCRF_FL, pTxConfig->Length);
 
-      if(READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_CSUM) != 0U)
+      if (READ_BIT(pTxConfig->Attributes, ETH_TX_PACKETS_FEATURES_CSUM) != (uint32_t)RESET)
       {
         /* Checksum Insertion Control */
         MODIFY_REG(dmatxdesc->DESC3, ETH_DMATXNDESCRF_CIC, pTxConfig->ChecksumCtrl);
@@ -2960,13 +3284,16 @@ static uint32_t ETH_Prepare_Tx_Descriptors(ETH_HandleTypeDef *heth, ETH_TxPacket
     }
 
     bd_count += 1U;
+
+    /* Ensure rest of descriptor is written to RAM before the OWN bit */
+    __DMB();
     /* Set Own bit */
     SET_BIT(dmatxdesc->DESC3, ETH_DMATXNDESCRF_OWN);
     /* Mark it as NORMAL descriptor */
     CLEAR_BIT(dmatxdesc->DESC3, ETH_DMATXNDESCRF_CTXT);
   }
 
-  if(ItMode != ((uint32_t)RESET))
+  if (ItMode != ((uint32_t)RESET))
   {
     /* Set Interrupt on completion bit */
     SET_BIT(dmatxdesc->DESC2, ETH_DMATXNDESCRF_IOC);
@@ -3003,8 +3330,7 @@ static void ETH_InitCallbacksToDefault(ETH_HandleTypeDef *heth)
   /* Init the ETH Callback settings */
   heth->TxCpltCallback   = HAL_ETH_TxCpltCallback;    /* Legacy weak TxCpltCallback   */
   heth->RxCpltCallback   = HAL_ETH_RxCpltCallback;    /* Legacy weak RxCpltCallback   */
-  heth->DMAErrorCallback = HAL_ETH_DMAErrorCallback;  /* Legacy weak DMAErrorCallback */
-  heth->MACErrorCallback = HAL_ETH_MACErrorCallback;  /* Legacy weak MACErrorCallback */
+  heth->ErrorCallback    = HAL_ETH_ErrorCallback;     /* Legacy weak ErrorCallback */
   heth->PMTCallback      = HAL_ETH_PMTCallback;       /* Legacy weak PMTCallback      */
   heth->EEECallback      = HAL_ETH_EEECallback;       /* Legacy weak EEECallback      */
   heth->WakeUpCallback   = HAL_ETH_WakeUpCallback;    /* Legacy weak WakeUpCallback   */
@@ -3027,4 +3353,3 @@ static void ETH_InitCallbacksToDefault(ETH_HandleTypeDef *heth)
   * @}
   */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Src/stm32h7xx_hal_eth_ex.c
+++ b/Src/stm32h7xx_hal_eth_ex.c
@@ -7,13 +7,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -71,7 +70,7 @@
 
 /** @defgroup ETHEx_Exported_Functions_Group1 Extended features functions
   * @brief    Extended features functions
- *
+  *
 @verbatim
  ===============================================================================
                       ##### Extended features functions #####
@@ -133,25 +132,26 @@ void HAL_ETHEx_SetARPAddressMatch(ETH_HandleTypeDef *heth, uint32_t IpAddress)
   *         that contains L4 filter configuration.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETHEx_SetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter , ETH_L4FilterConfigTypeDef *pL4FilterConfig)
+HAL_StatusTypeDef HAL_ETHEx_SetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
+                                              ETH_L4FilterConfigTypeDef *pL4FilterConfig)
 {
   __IO uint32_t *configreg = ((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter));
 
-  if(pL4FilterConfig == NULL)
+  if (pL4FilterConfig == NULL)
   {
     return HAL_ERROR;
   }
 
   /* Write configuration to (MACL3L4C0R + filter )register */
-  MODIFY_REG(*configreg, ETH_MACL4CR_MASK ,(pL4FilterConfig->Protocol |
+  MODIFY_REG(*configreg, ETH_MACL4CR_MASK, (pL4FilterConfig->Protocol |
                                             pL4FilterConfig->SrcPortFilterMatch |
-                                              pL4FilterConfig->DestPortFilterMatch));
+                                            pL4FilterConfig->DestPortFilterMatch));
 
   configreg = ((__IO uint32_t *)(&(heth->Instance->MACL4A0R) + Filter));
 
   /* Write configuration to (MACL4A0R + filter )register */
-  MODIFY_REG(*configreg, (ETH_MACL4AR_L4DP | ETH_MACL4AR_L4SP) , (pL4FilterConfig->SourcePort |
-                                                                                                                  (pL4FilterConfig->DestinationPort << 16)));
+  MODIFY_REG(*configreg, (ETH_MACL4AR_L4DP | ETH_MACL4AR_L4SP), (pL4FilterConfig->SourcePort |
+                                                                 (pL4FilterConfig->DestinationPort << 16)));
 
   /* Enable L4 filter */
   SET_BIT(heth->Instance->MACPFR, ETH_MACPFR_IPFE);
@@ -172,20 +172,25 @@ HAL_StatusTypeDef HAL_ETHEx_SetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t 
   *         that contains L4 filter configuration.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETHEx_GetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter, ETH_L4FilterConfigTypeDef *pL4FilterConfig)
+HAL_StatusTypeDef HAL_ETHEx_GetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
+                                              ETH_L4FilterConfigTypeDef *pL4FilterConfig)
 {
-  if(pL4FilterConfig == NULL)
+  if (pL4FilterConfig == NULL)
   {
     return HAL_ERROR;
   }
 
   /* Get configuration to (MACL3L4C0R + filter )register */
-  pL4FilterConfig->Protocol = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)), ETH_MACL3L4CR_L4PEN);
-  pL4FilterConfig->DestPortFilterMatch = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)), (ETH_MACL3L4CR_L4DPM | ETH_MACL3L4CR_L4DPIM));
-  pL4FilterConfig->SrcPortFilterMatch = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)), (ETH_MACL3L4CR_L4SPM | ETH_MACL3L4CR_L4SPIM));
+  pL4FilterConfig->Protocol = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)),
+                                       ETH_MACL3L4CR_L4PEN);
+  pL4FilterConfig->DestPortFilterMatch = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)),
+                                                  (ETH_MACL3L4CR_L4DPM | ETH_MACL3L4CR_L4DPIM));
+  pL4FilterConfig->SrcPortFilterMatch = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)),
+                                                 (ETH_MACL3L4CR_L4SPM | ETH_MACL3L4CR_L4SPIM));
 
   /* Get configuration to (MACL3L4C0R + filter )register */
-  pL4FilterConfig->DestinationPort = (READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL4A0R) + Filter)), ETH_MACL4AR_L4DP) >> 16);
+  pL4FilterConfig->DestinationPort = (READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL4A0R) + Filter)),
+                                               ETH_MACL4AR_L4DP) >> 16);
   pL4FilterConfig->SourcePort = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL4A0R) + Filter)), ETH_MACL4AR_L4SP);
 
   return HAL_OK;
@@ -204,11 +209,12 @@ HAL_StatusTypeDef HAL_ETHEx_GetL4FilterConfig(ETH_HandleTypeDef *heth, uint32_t 
   *         that contains L3 filter configuration.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETHEx_SetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter, ETH_L3FilterConfigTypeDef *pL3FilterConfig)
+HAL_StatusTypeDef HAL_ETHEx_SetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
+                                              ETH_L3FilterConfigTypeDef *pL3FilterConfig)
 {
   __IO uint32_t *configreg = ((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter));
 
-  if(pL3FilterConfig == NULL)
+  if (pL3FilterConfig == NULL)
   {
     return HAL_ERROR;
   }
@@ -216,12 +222,12 @@ HAL_StatusTypeDef HAL_ETHEx_SetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t 
   /* Write configuration to (MACL3L4C0R + filter )register */
   MODIFY_REG(*configreg, ETH_MACL3CR_MASK, (pL3FilterConfig->Protocol |
                                             pL3FilterConfig->SrcAddrFilterMatch |
-                                              pL3FilterConfig->DestAddrFilterMatch |
-                                                (pL3FilterConfig->SrcAddrHigherBitsMatch << 6) |
-                                                  (pL3FilterConfig->DestAddrHigherBitsMatch << 11)));
+                                            pL3FilterConfig->DestAddrFilterMatch |
+                                            (pL3FilterConfig->SrcAddrHigherBitsMatch << 6) |
+                                            (pL3FilterConfig->DestAddrHigherBitsMatch << 11)));
 
   /* Check if IPv6 protocol is selected */
-  if(pL3FilterConfig->Protocol != ETH_L3_IPV4_MATCH)
+  if (pL3FilterConfig->Protocol != ETH_L3_IPV4_MATCH)
   {
     /* Set the IPv6 address match */
     /* Set Bits[31:0] of 128-bit IP addr */
@@ -257,20 +263,26 @@ HAL_StatusTypeDef HAL_ETHEx_SetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t 
   *         that will contain the L3 filter configuration.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ETHEx_GetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter, ETH_L3FilterConfigTypeDef *pL3FilterConfig)
+HAL_StatusTypeDef HAL_ETHEx_GetL3FilterConfig(ETH_HandleTypeDef *heth, uint32_t Filter,
+                                              ETH_L3FilterConfigTypeDef *pL3FilterConfig)
 {
-  if(pL3FilterConfig == NULL)
+  if (pL3FilterConfig == NULL)
   {
     return HAL_ERROR;
   }
 
-  pL3FilterConfig->Protocol = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)), ETH_MACL3L4CR_L3PEN);
-  pL3FilterConfig->SrcAddrFilterMatch = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)), (ETH_MACL3L4CR_L3SAM | ETH_MACL3L4CR_L3SAIM));
-  pL3FilterConfig->DestAddrFilterMatch = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)), (ETH_MACL3L4CR_L3DAM | ETH_MACL3L4CR_L3DAIM));
-  pL3FilterConfig->SrcAddrHigherBitsMatch = (READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)), ETH_MACL3L4CR_L3HSBM) >> 6);
-  pL3FilterConfig->DestAddrHigherBitsMatch = (READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)), ETH_MACL3L4CR_L3HDBM) >> 11);
+  pL3FilterConfig->Protocol = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)),
+                                       ETH_MACL3L4CR_L3PEN);
+  pL3FilterConfig->SrcAddrFilterMatch = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)),
+                                                 (ETH_MACL3L4CR_L3SAM | ETH_MACL3L4CR_L3SAIM));
+  pL3FilterConfig->DestAddrFilterMatch = READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)),
+                                                  (ETH_MACL3L4CR_L3DAM | ETH_MACL3L4CR_L3DAIM));
+  pL3FilterConfig->SrcAddrHigherBitsMatch = (READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)),
+                                                      ETH_MACL3L4CR_L3HSBM) >> 6);
+  pL3FilterConfig->DestAddrHigherBitsMatch = (READ_BIT(*((__IO uint32_t *)(&(heth->Instance->MACL3L4C0R) + Filter)),
+                                                       ETH_MACL3L4CR_L3HDBM) >> 11);
 
-  if(pL3FilterConfig->Protocol != ETH_L3_IPV4_MATCH)
+  if (pL3FilterConfig->Protocol != ETH_L3_IPV4_MATCH)
   {
     pL3FilterConfig->Ip6Addr[0] = *((__IO uint32_t *)(&(heth->Instance->MACL3A0R0R) + Filter));
     pL3FilterConfig->Ip6Addr[1] = *((__IO uint32_t *)(&(heth->Instance->MACL3A1R0R) + Filter));
@@ -320,20 +332,25 @@ void HAL_ETHEx_DisableL3L4Filtering(ETH_HandleTypeDef *heth)
   */
 HAL_StatusTypeDef HAL_ETHEx_GetRxVLANConfig(ETH_HandleTypeDef *heth, ETH_RxVLANConfigTypeDef *pVlanConfig)
 {
-  if(pVlanConfig == NULL)
+  if (pVlanConfig == NULL)
   {
     return HAL_ERROR;
   }
 
-  pVlanConfig->InnerVLANTagInStatus = ((READ_BIT(heth->Instance->MACVTR, ETH_MACVTR_EIVLRXS) >> 31) == 0U) ? DISABLE : ENABLE;
+  pVlanConfig->InnerVLANTagInStatus = ((READ_BIT(heth->Instance->MACVTR,
+                                                 ETH_MACVTR_EIVLRXS) >> 31) == 0U) ? DISABLE : ENABLE;
   pVlanConfig->StripInnerVLANTag  = READ_BIT(heth->Instance->MACVTR, ETH_MACVTR_EIVLS);
   pVlanConfig->InnerVLANTag = ((READ_BIT(heth->Instance->MACVTR, ETH_MACVTR_ERIVLT) >> 27) == 0U) ? DISABLE : ENABLE;
-  pVlanConfig->DoubleVLANProcessing = ((READ_BIT(heth->Instance->MACVTR, ETH_MACVTR_EDVLP) >> 26) == 0U) ? DISABLE : ENABLE;
-  pVlanConfig->VLANTagHashTableMatch = ((READ_BIT(heth->Instance->MACVTR, ETH_MACVTR_VTHM) >> 25) == 0U) ? DISABLE : ENABLE;
+  pVlanConfig->DoubleVLANProcessing = ((READ_BIT(heth->Instance->MACVTR,
+                                                 ETH_MACVTR_EDVLP) >> 26) == 0U) ? DISABLE : ENABLE;
+  pVlanConfig->VLANTagHashTableMatch = ((READ_BIT(heth->Instance->MACVTR,
+                                                  ETH_MACVTR_VTHM) >> 25) == 0U) ? DISABLE : ENABLE;
   pVlanConfig->VLANTagInStatus = ((READ_BIT(heth->Instance->MACVTR, ETH_MACVTR_EVLRXS) >> 24) == 0U) ? DISABLE : ENABLE;
   pVlanConfig->StripVLANTag = READ_BIT(heth->Instance->MACVTR, ETH_MACVTR_EVLS);
-  pVlanConfig->VLANTypeCheck = READ_BIT(heth->Instance->MACVTR, (ETH_MACVTR_DOVLTC | ETH_MACVTR_ERSVLM | ETH_MACVTR_ESVL));
-  pVlanConfig->VLANTagInverceMatch = ((READ_BIT(heth->Instance->MACVTR, ETH_MACVTR_VTIM) >> 17) == 0U) ? DISABLE : ENABLE;
+  pVlanConfig->VLANTypeCheck = READ_BIT(heth->Instance->MACVTR,
+                                        (ETH_MACVTR_DOVLTC | ETH_MACVTR_ERSVLM | ETH_MACVTR_ESVL));
+  pVlanConfig->VLANTagInverceMatch = ((READ_BIT(heth->Instance->MACVTR, ETH_MACVTR_VTIM) >> 17) == 0U)
+                                     ? DISABLE : ENABLE;
 
   return HAL_OK;
 }
@@ -348,7 +365,7 @@ HAL_StatusTypeDef HAL_ETHEx_GetRxVLANConfig(ETH_HandleTypeDef *heth, ETH_RxVLANC
   */
 HAL_StatusTypeDef HAL_ETHEx_SetRxVLANConfig(ETH_HandleTypeDef *heth, ETH_RxVLANConfigTypeDef *pVlanConfig)
 {
-  if(pVlanConfig == NULL)
+  if (pVlanConfig == NULL)
   {
     return HAL_ERROR;
   }
@@ -356,13 +373,13 @@ HAL_StatusTypeDef HAL_ETHEx_SetRxVLANConfig(ETH_HandleTypeDef *heth, ETH_RxVLANC
   /* Write config to MACVTR */
   MODIFY_REG(heth->Instance->MACVTR, ETH_MACRXVLAN_MASK, (((uint32_t)pVlanConfig->InnerVLANTagInStatus << 31) |
                                                           pVlanConfig->StripInnerVLANTag |
-                                                            ((uint32_t)pVlanConfig->InnerVLANTag << 27) |
-                                                              ((uint32_t)pVlanConfig->DoubleVLANProcessing << 26) |
-                                                                ((uint32_t)pVlanConfig->VLANTagHashTableMatch << 25) |
-                                                                  ((uint32_t)pVlanConfig->VLANTagInStatus << 24) |
-                                                                    pVlanConfig->StripVLANTag |
-                                                                      pVlanConfig->VLANTypeCheck |
-                                                                        ((uint32_t)pVlanConfig->VLANTagInverceMatch << 17)));
+                                                          ((uint32_t)pVlanConfig->InnerVLANTag << 27) |
+                                                          ((uint32_t)pVlanConfig->DoubleVLANProcessing << 26) |
+                                                          ((uint32_t)pVlanConfig->VLANTagHashTableMatch << 25) |
+                                                          ((uint32_t)pVlanConfig->VLANTagInStatus << 24) |
+                                                          pVlanConfig->StripVLANTag |
+                                                          pVlanConfig->VLANTypeCheck |
+                                                          ((uint32_t)pVlanConfig->VLANTagInverceMatch << 17)));
 
   return HAL_OK;
 }
@@ -390,14 +407,15 @@ void HAL_ETHEx_SetVLANHashTable(ETH_HandleTypeDef *heth, uint32_t VLANHashTable)
   *         that will contain the Tx VLAN filter configuration.
   * @retval HAL Status.
   */
-HAL_StatusTypeDef HAL_ETHEx_GetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VLANTag ,ETH_TxVLANConfigTypeDef *pVlanConfig)
+HAL_StatusTypeDef HAL_ETHEx_GetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VLANTag,
+                                            ETH_TxVLANConfigTypeDef *pVlanConfig)
 {
   if (pVlanConfig == NULL)
   {
     return HAL_ERROR;
   }
 
-  if(VLANTag == ETH_INNER_TX_VLANTAG)
+  if (VLANTag == ETH_INNER_TX_VLANTAG)
   {
     pVlanConfig->SourceTxDesc = ((READ_BIT(heth->Instance->MACIVIR, ETH_MACVIR_VLTI) >> 20) == 0U) ? DISABLE : ENABLE;
     pVlanConfig->SVLANType = ((READ_BIT(heth->Instance->MACIVIR, ETH_MACVIR_CSVL) >> 19) == 0U) ? DISABLE : ENABLE;
@@ -424,13 +442,14 @@ HAL_StatusTypeDef HAL_ETHEx_GetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VL
   *         that contains Tx VLAN filter configuration.
   * @retval HAL Status
   */
-HAL_StatusTypeDef HAL_ETHEx_SetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VLANTag ,ETH_TxVLANConfigTypeDef *pVlanConfig)
+HAL_StatusTypeDef HAL_ETHEx_SetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VLANTag,
+                                            ETH_TxVLANConfigTypeDef *pVlanConfig)
 {
-  if(VLANTag == ETH_INNER_TX_VLANTAG)
+  if (VLANTag == ETH_INNER_TX_VLANTAG)
   {
     MODIFY_REG(heth->Instance->MACIVIR, ETH_MACTXVLAN_MASK, (((uint32_t)pVlanConfig->SourceTxDesc << 20) |
-                                                            ((uint32_t)pVlanConfig->SVLANType << 19) |
-                                                              pVlanConfig->VLANTagControl));
+                                                             ((uint32_t)pVlanConfig->SVLANType << 19) |
+                                                             pVlanConfig->VLANTagControl));
     /* Enable Double VLAN processing */
     SET_BIT(heth->Instance->MACVTR, ETH_MACVTR_EDVLP);
   }
@@ -438,7 +457,7 @@ HAL_StatusTypeDef HAL_ETHEx_SetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VL
   {
     MODIFY_REG(heth->Instance->MACVIR, ETH_MACTXVLAN_MASK, (((uint32_t)pVlanConfig->SourceTxDesc << 20) |
                                                             ((uint32_t)pVlanConfig->SVLANType << 19) |
-                                                              pVlanConfig->VLANTagControl));
+                                                            pVlanConfig->VLANTagControl));
   }
 
   return HAL_OK;
@@ -454,9 +473,9 @@ HAL_StatusTypeDef HAL_ETHEx_SetTxVLANConfig(ETH_HandleTypeDef *heth, uint32_t VL
   * @param  VLANIdentifier: VLAN Identifier 16 bit value
   * @retval None
   */
-void HAL_ETHEx_SetTxVLANIdentifier(ETH_HandleTypeDef *heth, uint32_t VLANTag ,uint32_t VLANIdentifier)
+void HAL_ETHEx_SetTxVLANIdentifier(ETH_HandleTypeDef *heth, uint32_t VLANTag, uint32_t VLANIdentifier)
 {
-  if(VLANTag == ETH_INNER_TX_VLANTAG)
+  if (VLANTag == ETH_INNER_TX_VLANTAG)
   {
     MODIFY_REG(heth->Instance->MACIVIR, ETH_MACVIR_VLT, VLANIdentifier);
   }
@@ -504,9 +523,10 @@ void HAL_ETHEx_EnterLPIMode(ETH_HandleTypeDef *heth, FunctionalState TxAutomate,
   __HAL_ETH_MAC_ENABLE_IT(heth, ETH_MACIER_LPIIE);
 
   /* Write to LPI Control register: Enter low power mode */
-  MODIFY_REG(heth->Instance->MACLCSR, (ETH_MACLCSR_LPIEN | ETH_MACLCSR_LPITXA | ETH_MACLCSR_LPITCSE), (((uint32_t)TxAutomate << 19) |
-                                                                                                       ((uint32_t)TxClockStop << 21) |
-                                                                                                         ETH_MACLCSR_LPIEN));
+  MODIFY_REG(heth->Instance->MACLCSR, (ETH_MACLCSR_LPIEN | ETH_MACLCSR_LPITXA | ETH_MACLCSR_LPITCSE),
+             (((uint32_t)TxAutomate << 19) |
+              ((uint32_t)TxClockStop << 21) |
+              ETH_MACLCSR_LPIEN));
 }
 
 /**
@@ -556,4 +576,3 @@ uint32_t HAL_ETHEx_GetMACLPIEvent(ETH_HandleTypeDef *heth)
   * @}
   */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
The reworked Ethernet HAL driver brings multiple changes and a compatibility break vs. previous Ethernet HAL driver.
Main changes are listed here:
- Add support for PTP and ARP
- Rework packets reception and buffers allocation for better integration and performance
- Rework packets transmission and buffers allocation (using interrupts instead of polling and prevent packets lock during transmission)
- Enhance DMA management
- Decouple Ethernet HAL driver from PHY driver
- Enhance maximum throughput in RX (94Mbs) and TX (92Mbs)
- Enhance footprint (new driver size is 6% less than previous driver)
- Full integration with LwIP (with and without FreeRTOS) and NetXDuo with ThreadX.
- MISRA-C 2012, code coverage analysis, static code analysis and robustness validation added.
