### PR TITLE
fix the bug that the spi suspend flag is not cleared

### DIFF
--- a/Src/stm32h7xx_hal_spi.c
+++ b/Src/stm32h7xx_hal_spi.c
@@ -1121,6 +1121,11 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
       }
       else
       {
+        /* Clear the suspend flag to make receive start again */
+        if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_SUSP))
+        {
+          __HAL_SPI_CLEAR_SUSPFLAG(hspi);
+        }
         /* Timeout management */
         if ((((HAL_GetTick() - tickstart) >=  Timeout) && (Timeout != HAL_MAX_DELAY)) || (Timeout == 0U))
         {
@@ -1156,6 +1161,11 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
       }
       else
       {
+        /* Clear the suspend flag to make receive start again */
+        if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_SUSP))
+        {
+          __HAL_SPI_CLEAR_SUSPFLAG(hspi);
+        }
         /* Timeout management */
         if ((((HAL_GetTick() - tickstart) >=  Timeout) && (Timeout != HAL_MAX_DELAY)) || (Timeout == 0U))
         {
@@ -1187,6 +1197,11 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
       }
       else
       {
+        /* Clear the suspend flag to make receive start again */
+        if(__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_SUSP))
+        {
+          __HAL_SPI_CLEAR_SUSPFLAG(hspi);
+        }
         /* Timeout management */
         if ((((HAL_GetTick() - tickstart) >=  Timeout) && (Timeout != HAL_MAX_DELAY)) || (Timeout == 0U))
         {


### PR DESCRIPTION
This PR fix the issue #47 .

The thing is that the SPI master in the rx only mode won't wait the CPU to get data from the fifo. So if a interrupt occured during the `HAL_SPI_Receive`, data will lose and the `while (hspi->RxXferCount > 0UL)` will nerver exit, which will then cause a timeout error.

There is actually a bit `MASRX` designed for the SPI mater to wait CPU, but after the CPU get data, the SUSP flag need to be cleared in order to start the receive according to the reference manual.

Without clearing the susp bit, the SPI master won't receive data anymore, which will also cause a timeout.  Very much like the case without setting MASRX.

This PR fixed this bug by adding codes to clear the susp flag in `HAL_SPI_Receive`. After my testing, I think it works very well.

![image](https://github.com/STMicroelectronics/stm32h7xx_hal_driver/assets/34576789/9694e6d7-d29e-451a-812d-72987eca4fdc)
