### PR TITLE
HCD: Re-activate the USB channel if not ready.

### DIFF
--- a/Src/stm32h7xx_hal_hcd.c
+++ b/Src/stm32h7xx_hal_hcd.c
@@ -1693,6 +1693,12 @@ static void HCD_HC_OUT_IRQHandler(HCD_HandleTypeDef *hhcd, uint8_t chnum)
       else
       {
         hhcd->hc[chnum].urb_state = URB_NOTREADY;
+
+        /* re-activate the channel  */
+        tmpreg = USBx_HC(chnum)->HCCHAR;
+        tmpreg &= ~USB_OTG_HCCHAR_CHDIS;
+        tmpreg |= USB_OTG_HCCHAR_CHENA;
+        USBx_HC(chnum)->HCCHAR = tmpreg;
       }
     }
     __HAL_HCD_CLEAR_HC_INT(chnum, USB_OTG_HCINT_TXERR);


### PR DESCRIPTION
Otherwise the ErrCnt doesn't work, and the HAL_HCD_HC_NotifyURBChange_Callback never gets invoked.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/stm32h7xx_hal_driver/blob/master/CONTRIBUTING.md) file.
