### PR TITLE
Fix HAL_FDCAN_GetRxMessage GetIndex computation overflow in overwrite mode

### DIFF
--- a/Src/stm32h7xx_hal_fdcan.c
+++ b/Src/stm32h7xx_hal_fdcan.c
@@ -2973,18 +2973,25 @@ HAL_StatusTypeDef HAL_FDCAN_GetRxMessage(FDCAN_HandleTypeDef *hfdcan, uint32_t R
       }
       else
       {
+      {
+        /* Calculate Rx FIFO 0 element index */
+        GetIndex = ((hfdcan->Instance->RXF0S & FDCAN_RXF0S_F0GI) >> FDCAN_RXF0S_F0GI_Pos);
+
         /* Check that the Rx FIFO 0 is full & overwrite mode is on */
         if (((hfdcan->Instance->RXF0S & FDCAN_RXF0S_F0F) >> FDCAN_RXF0S_F0F_Pos) == 1U)
         {
           if (((hfdcan->Instance->RXF0C & FDCAN_RXF0C_F0OM) >> FDCAN_RXF0C_F0OM_Pos) == FDCAN_RX_FIFO_OVERWRITE)
           {
             /* When overwrite status is on discard first message in FIFO */
-            GetIndex = 1U;
+            GetIndex++;
+
+            /* Wrap around if GetIndex points after the end of FIFO */
+            if (GetIndex == (hfdcan->Instance->RXF0C & FDCAN_RXF0C_F0S) >> FDCAN_RXF0C_F0S_Pos)
+            {
+              GetIndex = 0;
+            }
           }
         }
-
-        /* Calculate Rx FIFO 0 element index */
-        GetIndex += ((hfdcan->Instance->RXF0S & FDCAN_RXF0S_F0GI) >> FDCAN_RXF0S_F0GI_Pos);
 
         /* Calculate Rx FIFO 0 element address */
         RxAddress = (uint32_t *)(hfdcan->msgRam.RxFIFO0SA + (GetIndex * hfdcan->Init.RxFifo0ElmtSize * 4U));
@@ -3011,18 +3018,24 @@ HAL_StatusTypeDef HAL_FDCAN_GetRxMessage(FDCAN_HandleTypeDef *hfdcan, uint32_t R
       }
       else
       {
+        /* Calculate Rx FIFO 1 element index */
+        GetIndex = ((hfdcan->Instance->RXF1S & FDCAN_RXF1S_F1GI) >> FDCAN_RXF1S_F1GI_Pos);
+
         /* Check that the Rx FIFO 1 is full & overwrite mode is on */
         if (((hfdcan->Instance->RXF1S & FDCAN_RXF1S_F1F) >> FDCAN_RXF1S_F1F_Pos) == 1U)
         {
           if (((hfdcan->Instance->RXF1C & FDCAN_RXF1C_F1OM) >> FDCAN_RXF1C_F1OM_Pos) == FDCAN_RX_FIFO_OVERWRITE)
           {
             /* When overwrite status is on discard first message in FIFO */
-            GetIndex = 1U;
+            GetIndex++;
+
+            /* Wrap around if GetIndex points after the end of FIFO */
+            if (GetIndex == (hfdcan->Instance->RXF1C & FDCAN_RXF1C_F1S) >> FDCAN_RXF1C_F1S_Pos)
+            {
+              GetIndex = 0;
+            }
           }
         }
-
-        /* Calculate Rx FIFO 1 element index */
-        GetIndex += ((hfdcan->Instance->RXF1S & FDCAN_RXF1S_F1GI) >> FDCAN_RXF1S_F1GI_Pos);
 
         /* Calculate Rx FIFO 1 element address */
         RxAddress = (uint32_t *)(hfdcan->msgRam.RxFIFO1SA + (GetIndex * hfdcan->Init.RxFifo1ElmtSize * 4U));


### PR DESCRIPTION
This fixes a buffer overflow that was likely caused by an incomplete fix of #3

When the CAN peripheral RX FIFO is configured in overwrite mode, the `GetIndex` is (correctly) incremented by 1 to avoid reading from the element the peripheral might be writing to:

https://github.com/STMicroelectronics/stm32h7xx-hal-driver/blob/dbfb749f229e1aa89e50b54229ca87766e180d2d/Src/stm32h7xx_hal_fdcan.c#L3015-L3028

However, this ignores the fact that `GetIndex` might be pointing at the last element, in which case it has to be wrapped around instead. This PR fixes this by moving the offset-by-1 after the main `GetIndex` computation, and sets `GetIndex` to 0 if it overflowed. This should be the most performant way to do it, as the check is only done when the FIFO is actually full and overwrite mode is enabled.

