### PR TITLE
Fix DMA callback references for memory buffers

### DIFF
--- a/Src/stm32h7xx_hal_dma.c
+++ b/Src/stm32h7xx_hal_dma.c
@@ -1444,19 +1444,19 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
         /* Current memory buffer used is Memory 0 */
         if((ccr_reg & BDMA_CCR_CT) == 0U)
         {
-          if(hdma->XferM1HalfCpltCallback != NULL)
+          if(hdma->XferHalfCpltCallback != NULL)
           {
-            /* Half transfer Callback for Memory 1 */
-            hdma->XferM1HalfCpltCallback(hdma);
+            /* Half transfer Callback for Memory 0 */
+            hdma->XferHalfCpltCallback(hdma);
           }
         }
         /* Current memory buffer used is Memory 1 */
         else
         {
-          if(hdma->XferHalfCpltCallback != NULL)
+          if(hdma->XferM1HalfCpltCallback != NULL)
           {
-            /* Half transfer Callback for Memory 0 */
-            hdma->XferHalfCpltCallback(hdma);
+            /* Half transfer Callback for Memory 1 */
+            hdma->XferM1HalfCpltCallback(hdma);
           }
         }
       }


### PR DESCRIPTION
For the BDMA the order of the half completed interrupt calls seems in the wrong order.

If I am at a HALF interrupt I have also to call the corresponding interrupt of the SAME buffer (because it is obviously not completed yet). Compare with the Half Transfer Complete Interrupt management of the regular DMA.

Just stumbled upon this without further research. You might want to check your entire code base for the correct call assignment of Xfer*CpltCallback depending on DMA_SxCR_CT.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/stm32h7xx_hal_driver/blob/master/CONTRIBUTING.md) file.
